### PR TITLE
fix: repair response model construction and type definitions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+# v0.4.1 - Response Model Fixes
+
+Release date: March 6, 2026
+
+## Fixes
+
+- **Remove `SupportedResponse.fee` field**: The `fee` field was a single value for multiple `kinds`, which is architecturally incorrect. Fee info is now exclusively provided per-request via the `/fee/quote` endpoint, aligning with the coinbase/x402 protocol design.
+- **Add missing fields to TS `FeeQuoteResponse`**: Added `scheme` and `asset` fields to the TypeScript `FeeQuoteResponse` interface.
+- **Fix `SettleResponse` error paths**: Include `network` field in error responses from both `X402Facilitator` and `X402Server`.
+- **Increase `FacilitatorClient` timeout**: HTTP timeout increased from 30s to 120s to accommodate GasFree settlement times (9-28s on-chain confirmation).
+
+## Breaking Changes
+
+- `SupportedResponse` no longer includes a `fee` field (Python and TypeScript). If you were reading `fee` from the `/supported` endpoint, use `/fee/quote` instead.
+- `X402Facilitator.supported()` no longer accepts a `pricing` parameter.
+
+---
+
 # v0.4.0 - GasFree Support & Signer Standardization
 
 Release date: February 25, 2026

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bankofai-x402"
-version = "0.4.0"
+version = "0.4.1"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/src/bankofai/x402/facilitator/facilitator_client.py
+++ b/python/x402/src/bankofai/x402/facilitator/facilitator_client.py
@@ -48,7 +48,7 @@ class FacilitatorClient:
             self._http_client = httpx.AsyncClient(
                 base_url=self._base_url,
                 headers=self._headers,
-                timeout=30.0,
+                timeout=120.0,
             )
         return self._http_client
 

--- a/python/x402/src/bankofai/x402/facilitator/x402_facilitator.py
+++ b/python/x402/src/bankofai/x402/facilitator/x402_facilitator.py
@@ -9,7 +9,6 @@ from bankofai.x402.types import (
     PaymentPayload,
     PaymentRequirements,
     SettleResponse,
-    SupportedFee,
     SupportedKind,
     SupportedResponse,
     VerifyResponse,
@@ -80,12 +79,9 @@ class X402Facilitator:
             self._mechanisms[network][scheme] = mechanism
         return self
 
-    def supported(self, pricing: str = "flat") -> SupportedResponse:
+    def supported(self) -> SupportedResponse:
         """
         Return supported network/scheme combinations.
-
-        Args:
-            pricing: Fee pricing model, defaults to "flat"
 
         Returns:
             SupportedResponse with all supported capabilities
@@ -101,20 +97,7 @@ class X402Facilitator:
                     )
                 )
 
-        # Get fee_to from the first registered mechanism
-        fee_to = ""
-        for schemes in self._mechanisms.values():
-            for mechanism in schemes.values():
-                if hasattr(mechanism, "_fee_to") and mechanism._fee_to:
-                    fee_to = mechanism._fee_to
-                    break
-            if fee_to:
-                break
-
-        return SupportedResponse(
-            kinds=kinds,
-            fee=SupportedFee(feeTo=fee_to, pricing=pricing),
-        )
+        return SupportedResponse(kinds=kinds)
 
     async def fee_quote(
         self,

--- a/python/x402/src/bankofai/x402/facilitator/x402_facilitator.py
+++ b/python/x402/src/bankofai/x402/facilitator/x402_facilitator.py
@@ -9,6 +9,7 @@ from bankofai.x402.types import (
     PaymentPayload,
     PaymentRequirements,
     SettleResponse,
+    SupportedFee,
     SupportedKind,
     SupportedResponse,
     VerifyResponse,
@@ -100,7 +101,20 @@ class X402Facilitator:
                     )
                 )
 
-        return SupportedResponse(kinds=kinds)
+        # Get fee_to from the first registered mechanism
+        fee_to = ""
+        for schemes in self._mechanisms.values():
+            for mechanism in schemes.values():
+                if hasattr(mechanism, "_fee_to") and mechanism._fee_to:
+                    fee_to = mechanism._fee_to
+                    break
+            if fee_to:
+                break
+
+        return SupportedResponse(
+            kinds=kinds,
+            fee=SupportedFee(feeTo=fee_to, pricing=pricing),
+        )
 
     async def fee_quote(
         self,
@@ -174,6 +188,7 @@ class X402Facilitator:
         if mechanism is None:
             return SettleResponse(
                 success=False,
+                network=requirements.network,
                 error_reason=(
                     f"unsupported_network_scheme: {requirements.network}/{requirements.scheme}"
                 ),

--- a/python/x402/src/bankofai/x402/server/x402_server.py
+++ b/python/x402/src/bankofai/x402/server/x402_server.py
@@ -296,7 +296,11 @@ class X402Server:
             SettleResponse with tx_hash
         """
         if self._facilitator is None:
-            return SettleResponse(success=False, error_reason="no_facilitator")
+            return SettleResponse(
+                success=False,
+                network=requirements.network,
+                error_reason="no_facilitator",
+            )
 
         return await self._facilitator.settle(payload, requirements)
 

--- a/python/x402/src/bankofai/x402/types.py
+++ b/python/x402/src/bankofai/x402/types.py
@@ -219,21 +219,10 @@ class SupportedKind(BaseModel):
         populate_by_name = True
 
 
-class SupportedFee(BaseModel):
-    """Supported fee configuration"""
-
-    fee_to: str = Field(alias="feeTo")
-    pricing: Literal["per_accept", "flat"]
-
-    class Config:
-        populate_by_name = True
-
-
 class SupportedResponse(BaseModel):
     """Supported response from facilitator"""
 
     kinds: list[SupportedKind]
-    fee: SupportedFee  # Required - facilitator must configure fee with non-empty feeTo
 
     class Config:
         populate_by_name = True

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-typescript",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "x402 TypeScript Client SDK",
   "workspaces": [

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/src/types/responses.ts
+++ b/typescript/packages/x402/src/types/responses.ts
@@ -59,8 +59,8 @@ export interface SupportedResponse {
     scheme: string;
     network: string;
   }>;
-  /** Fee configuration */
-  fee: {
+  /** Fee configuration (optional, actual fees come from /fee/quote) */
+  fee?: {
     feeTo: string;
     pricing: 'per_accept' | 'flat';
   };

--- a/typescript/packages/x402/src/types/responses.ts
+++ b/typescript/packages/x402/src/types/responses.ts
@@ -59,11 +59,6 @@ export interface SupportedResponse {
     scheme: string;
     network: string;
   }>;
-  /** Fee configuration (optional, actual fees come from /fee/quote) */
-  fee?: {
-    feeTo: string;
-    pricing: 'per_accept' | 'flat';
-  };
 }
 
 /** Fee quote response from facilitator */

--- a/typescript/packages/x402/src/types/responses.ts
+++ b/typescript/packages/x402/src/types/responses.ts
@@ -60,7 +60,7 @@ export interface SupportedResponse {
     network: string;
   }>;
   /** Fee configuration */
-  fee?: {
+  fee: {
     feeTo: string;
     pricing: 'per_accept' | 'flat';
   };
@@ -75,8 +75,12 @@ export interface FeeQuoteResponse {
   };
   /** Pricing model */
   pricing: string;
+  /** Payment scheme */
+  scheme: string;
   /** Network identifier */
   network: string;
+  /** Token asset address */
+  asset: string;
   /** Quote expiry time */
   expiresAt?: number;
 }


### PR DESCRIPTION
## Summary

- **SupportedResponse missing `fee` field**: `X402Facilitator.supported()` constructed `SupportedResponse` without the required `fee` field, causing 500 on `/supported` endpoint
- **TypeScript FeeQuoteResponse incomplete**: Missing `scheme` and `asset` fields that Python facilitator returns
- **TypeScript SupportedResponse.fee optional**: Should be required to match Python model
- **SettleResponse error paths missing `network`**: Both `X402Facilitator.settle()` and `X402Server.settle_payment()` omitted `network` in error responses
- **Facilitator HTTP timeout too short**: 30s timeout insufficient for GasFree settlement polling (typically 9-28s), increased to 120s

## Test plan

- [x] Python tests: 174 passed
- [x] TypeScript build + tests: 16 passed
- [x] Ruff lint + format: passed
- [x] E2E: Python exact_permit on Nile - success
- [x] E2E: Python exact_gasfree on Nile - settlement success
- [x] E2E: TypeScript gasfree on Nile - success