### PR TITLE
feat(registry): update USDD to use permit2 on TRON networks

### DIFF
--- a/python/x402/src/bankofai/x402/registry.py
+++ b/python/x402/src/bankofai/x402/registry.py
@@ -197,6 +197,7 @@ class AssetRegistry:
                     name="Decentralized USD",
                     version="1",
                     supports_eip2612=True,
+                    asset_transfer_method="permit2",
                 ),
             },
         )
@@ -233,6 +234,7 @@ class AssetRegistry:
                     name="Decentralized USD",
                     version="1",
                     supports_eip2612=True,
+                    asset_transfer_method="permit2",
                 ),
             },
         )

--- a/python/x402/tests/unit/core/test_asset_registry.py
+++ b/python/x402/tests/unit/core/test_asset_registry.py
@@ -113,7 +113,7 @@ class TestAssetRegistry:
         usdd = registry.resolve("tron:mainnet", "USDD")
         assert usdd.decimals == 18
         assert usdd.supports_eip2612 is True
-        assert usdd.asset_transfer_method is None
+        assert usdd.asset_transfer_method == "permit2"
 
     def test_builtin_tron_testnet_tokens(self) -> None:
         registry = AssetRegistry()

--- a/typescript/packages/core/src/registry/assetRegistry.ts
+++ b/typescript/packages/core/src/registry/assetRegistry.ts
@@ -211,6 +211,7 @@ export class AssetRegistry {
         name: "Decentralized USD",
         version: "1",
         supportsEip2612: true,
+        assetTransferMethod: "permit2",
       },
     });
     this.defaults.set("tron:mainnet", "USDT");
@@ -240,6 +241,7 @@ export class AssetRegistry {
         name: "Decentralized USD",
         version: "1",
         supportsEip2612: true,
+        assetTransferMethod: "permit2",
       },
     });
     this.defaults.set("tron:nile", "USDT");

--- a/typescript/packages/core/test/unit/registry/assetRegistry.test.ts
+++ b/typescript/packages/core/test/unit/registry/assetRegistry.test.ts
@@ -45,7 +45,7 @@ describe("AssetRegistry", () => {
       const usdd = registry.resolve("tron:mainnet" as Network, "USDD");
       expect(usdd.decimals).toBe(18);
       expect(usdd.supportsEip2612).toBe(true);
-      expect(usdd.assetTransferMethod).toBeUndefined();
+      expect(usdd.assetTransferMethod).toBe("permit2");
     });
 
     it("should have TRON testnet tokens", () => {


### PR DESCRIPTION
## Summary
- Updated USDD configuration in `AssetRegistry` for TRON networks (Mainnet and Nile).
- Set `assetTransferMethod` to `permit2` for USDD to ensure it doesn't default to EIP-3009/TIP-712.
- Maintained USDD's support for EIP-2612.
- Updated corresponding unit tests in both Python and TypeScript SDKs.