### PR TITLE
Fix GasFree TIP-712 EVM address conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-03-26
+
+### Fixed
+- TypeScript GasFree TIP-712 signing now converts all address fields to EVM `0x` format before signing
+
+### Added
+- Tests to assert GasFree TIP-712 signing uses EVM-formatted addresses (TypeScript and Python)
+
 ## [0.5.0] - 2026-03-18
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,77 +1,17 @@
-# v0.5.0 - Wallet-Based Signer Standardization
+# v0.5.1 - GasFree TIP-712 Address Fix
 
-Release date: March 18, 2026
+Release date: March 26, 2026
 
 ## What's New
 
-- **Breaking change: signer initialization now uses `create()`**: Signers no longer support direct initialization from a private key. Use `create()` instead, which constructs the agent wallet internally and resolves signer setup through the new wallet-based flow. Before calling `create()`, configure agent-wallet through its supported environment variables or local wallet configuration.
-- **Unified wallet capability surface**: Signer integration is now standardized around the agent-wallet `Wallet` interface for message signing, typed-data signing, and transaction signing. This creates a single capability model across supported signer flows.
-
-## How It Works
-
-`create()` resolves the agent wallet using this order:
-
-1. `AGENT_WALLET_PRIVATE_KEY`for static wallet mode
-2. `AGENT_WALLET_PASSWORD` with optional `AGENT_WALLET_DIR` for local wallet mode
-3. Raises a configuration error if no valid wallet configuration is found
-
-Once resolved, the signer wraps the agent-wallet `Wallet` interface, which supports:
-
-- `sign_message()` / `signMessage()` for message signing
-- `sign_typed_data()` / `signTypedData()` for typed-data signing
-- `sign_transaction()` / `signTransaction()` for transaction signing
+- **GasFree TIP-712 signing now uses EVM addresses**: The TypeScript GasFree client converts all address fields to EVM `0x` format before signing to ensure signatures match the expected domain/message encoding.
+- **Stronger test coverage**: Added tests in both TypeScript and Python to assert that GasFree TIP-712 signing uses EVM-formatted addresses.
 
 ## Breaking Changes
 
-### Migration Example
-
-The `create()` flow expects agent-wallet to be configured first. In static mode, this typically means setting `AGENT_WALLET_PRIVATE_KEY` or `AGENT_WALLET_MNEMONIC`. In local mode, configure `AGENT_WALLET_PASSWORD` and optionally `AGENT_WALLET_DIR`.
-
-#### Python Client
-
-```python
-# old
-tron_signer = TronClientSigner.from_private_key(TRON_PRIVATE_KEY)
-evm_signer = EvmClientSigner.from_private_key(BSC_PRIVATE_KEY)
-```
-
-```python
-# new
-tron_signer = await TronClientSigner.create()
-evm_signer = await EvmClientSigner.create()
-```
-
-#### TypeScript Client
-
-```ts
-// old
-const tronSigner = new TronClientSigner(TRON_PRIVATE_KEY);
-const evmSigner = new EvmClientSigner(BSC_PRIVATE_KEY);
-```
-
-```ts
-// new
-const tronSigner = await TronClientSigner.create();
-const evmSigner = await EvmClientSigner.create();
-```
-
-#### Facilitator (Python only)
-
-The TypeScript SDK does not expose a separate facilitator signer. Facilitator-side signing is handled in the Python server implementation.
-
-```python
-# old
-tron_signer = TronFacilitatorSigner.from_private_key(TRON_PRIVATE_KEY)
-bsc_signer = EvmFacilitatorSigner.from_private_key(BSC_PRIVATE_KEY)
-```
-
-```python
-# new
-tron_signer = await TronFacilitatorSigner.create()
-bsc_signer = await EvmFacilitatorSigner.create()
-```
+None.
 
 ## Affected SDKs
 
-- **Python**: `bankofai-x402==0.5.0`
-- **TypeScript**: `@bankofai/x402@0.5.0`
+- **Python**: `bankofai-x402==0.5.1`
+- **TypeScript**: `@bankofai/x402@0.5.1`

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.5.0"
+version = "0.5.1"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/tests/exact/test_gasfree_client.py
+++ b/python/x402/tests/exact/test_gasfree_client.py
@@ -81,6 +81,13 @@ class TestGasFreeClient:
         # Verify primary_type was passed
         mock_signer.sign_typed_data.assert_called_once()
         assert mock_signer.sign_typed_data.call_args.kwargs["primary_type"] == GASFREE_PRIMARY_TYPE
+        domain = mock_signer.sign_typed_data.call_args.kwargs["domain"]
+        message = mock_signer.sign_typed_data.call_args.kwargs["message"]
+        assert domain["verifyingContract"].startswith("0x")
+        assert message["token"].startswith("0x")
+        assert message["serviceProvider"].startswith("0x")
+        assert message["user"].startswith("0x")
+        assert message["receiver"].startswith("0x")
 
     @pytest.mark.anyio
     async def test_max_fee_adjustment(self, mock_signer, nile_requirements, mock_api_client):

--- a/python/x402/tests/exact/test_gasfree_client.py
+++ b/python/x402/tests/exact/test_gasfree_client.py
@@ -12,6 +12,7 @@ from bankofai.x402.types import FeeInfo, PaymentRequirements, PaymentRequirement
 
 USDT_ADDRESS = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"
 PROVIDER_ADDRESS = "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E"
+MERCHANT_ADDRESS = "THKbWd2g5aS9tY59xk8hp5xMnbE8m3B3E"
 
 
 @pytest.fixture
@@ -30,7 +31,7 @@ def nile_requirements():
         network="tron:nile",
         amount="1000000",
         asset=USDT_ADDRESS,
-        payTo="TMerchantAddr12345678901234567890",
+        payTo=MERCHANT_ADDRESS,
         maxTimeoutSeconds=3600,
         extra=PaymentRequirementsExtra(
             fee=FeeInfo(feeTo=PROVIDER_ADDRESS, feeAmount="0"),
@@ -58,7 +59,7 @@ def mock_api_client():
             }
         )
         client_instance.get_providers = AsyncMock(
-            return_value=[{"address": "TMerchantAddr12345678901234567890"}]
+            return_value=[{"address": MERCHANT_ADDRESS}]
         )
         yield client_instance
 
@@ -122,7 +123,7 @@ class TestGasFreeClient:
             network="tron:nile",
             amount="1000000",
             asset=USDT_ADDRESS,
-            payTo="TMerchantAddr12345678901234567890",
+            payTo=MERCHANT_ADDRESS,
         )
 
         mechanism = ExactGasFreeClientMechanism(mock_signer, clients={"tron:nile": mock_api_client})
@@ -277,7 +278,7 @@ class TestGasFreeClient:
             network="tron:nile",
             amount="1000000",
             asset=USDT_ADDRESS,
-            payTo="TMerchantAddr12345678901234567890",
+            payTo=MERCHANT_ADDRESS,
             maxTimeoutSeconds=3600,
             extra=PaymentRequirementsExtra(
                 fee=FeeInfo(feeTo=PROVIDER_ADDRESS, feeAmount="5000000"),
@@ -350,7 +351,7 @@ class TestGasFreeClient:
             network="tron:nile",
             amount="1000000",
             asset=USDT_ADDRESS,
-            payTo="TMerchantAddr12345678901234567890",
+            payTo=MERCHANT_ADDRESS,
         )
 
         mechanism = ExactGasFreeClientMechanism(mock_signer, clients={"tron:nile": mock_api_client})

--- a/python/x402/tests/exact/test_gasfree_client.py
+++ b/python/x402/tests/exact/test_gasfree_client.py
@@ -58,9 +58,7 @@ def mock_api_client():
                 ],
             }
         )
-        client_instance.get_providers = AsyncMock(
-            return_value=[{"address": MERCHANT_ADDRESS}]
-        )
+        client_instance.get_providers = AsyncMock(return_value=[{"address": MERCHANT_ADDRESS}])
         yield client_instance
 
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x402-typescript",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x402-typescript",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "workspaces": [
         "packages/*"
       ],
@@ -4321,7 +4321,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-typescript",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "x402 TypeScript Client SDK",
   "workspaces": [

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
@@ -3,6 +3,41 @@ import { ExactGasFreeClientMechanism } from './exactGasfree.js';
 import { GasFreeAPIClient } from '../utils/gasfree.js';
 import { PaymentRequirements, ClientSigner } from '../index.js';
 
+const assembleGasFreeTransactionJson = vi.fn((params: any) => ({
+  domain: {
+    name: 'GasFreeController',
+    version: 'V1.0.0',
+    chainId: 1,
+    verifyingContract: params.serviceProvider,
+  },
+  types: {
+    PermitTransfer: [],
+  },
+  message: {
+    token: params.token,
+    serviceProvider: params.serviceProvider,
+    user: params.user,
+    receiver: params.receiver,
+    value: params.value,
+    maxFee: params.maxFee,
+    deadline: params.deadline,
+    version: params.version,
+    nonce: params.nonce,
+  },
+}));
+
+vi.mock('@gasfree/gasfree-sdk', () => {
+  return {
+    default: {
+      TronGasFree: class {
+        assembleGasFreeTransactionJson(params: any) {
+          return assembleGasFreeTransactionJson(params);
+        }
+      },
+    },
+  };
+});
+
 vi.mock('../utils/gasfree.js', () => {
   return {
     GasFreeAPIClient: vi.fn().mockImplementation(() => {
@@ -37,6 +72,7 @@ describe('ExactGasFreeClientMechanism', () => {
   let mockApiClient: any;
 
   beforeEach(() => {
+    assembleGasFreeTransactionJson.mockClear();
     mockApiClient = new GasFreeAPIClient('url');
     mockSigner = {
       getAddress: vi.fn().mockReturnValue(MOCK_ADDR),
@@ -68,11 +104,11 @@ describe('ExactGasFreeClientMechanism', () => {
     expect(payload.extensions?.gasfreeAddress).toBe('TLCvf7MktLG7XkbJRyUwnvCeDnaEXYkcbC');
 
     const [domain, _types, message] = mockSigner.signTypedData.mock.calls[0];
-    expect(String(domain.verifyingContract).startsWith('0x')).toBe(true);
-    expect(String(message.token).startsWith('0x')).toBe(true);
-    expect(String(message.serviceProvider).startsWith('0x')).toBe(true);
-    expect(String(message.user).startsWith('0x')).toBe(true);
-    expect(String(message.receiver).startsWith('0x')).toBe(true);
+    expect(domain.verifyingContract).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(message.token).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(message.serviceProvider).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(message.user).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(message.receiver).toMatch(/^0x[0-9a-fA-F]{40}$/);
   });
 
   it('should adjust maxFee to protocol minimum', async () => {
@@ -147,6 +183,49 @@ describe('ExactGasFreeClientMechanism', () => {
 
     // maxFee should be transferFee (1000000) + activateFee (2050000) = 3050000
     expect(payload.payload.paymentPermit?.fee.feeAmount).toBe('3050000');
+  });
+
+  it('should throw when address conversion fails', async () => {
+    assembleGasFreeTransactionJson.mockImplementationOnce(() => ({
+      domain: {
+        name: 'GasFreeController',
+        version: 'V1.0.0',
+        chainId: 1,
+        verifyingContract: 'invalid',
+      },
+      types: {
+        PermitTransfer: [],
+      },
+      message: {
+        token: 'invalid',
+        serviceProvider: 'invalid',
+        user: 'invalid',
+        receiver: 'invalid',
+        value: '1',
+        maxFee: '1',
+        deadline: '1',
+        version: '1',
+        nonce: '1',
+      },
+    }));
+
+    const requirements: PaymentRequirements = {
+      scheme: 'exact_gasfree',
+      network: 'tron:nile',
+      amount: '1000000',
+      asset: USDT_ADDRESS,
+      payTo: MOCK_ADDR,
+      extra: {
+        fee: {
+          feeTo: MOCK_ADDR,
+          feeAmount: '0',
+        },
+      },
+    };
+
+    await expect(
+      mechanism.createPaymentPayload(requirements, 'https://example.com/res')
+    ).rejects.toThrow('GasFree TIP-712: could not convert');
   });
 
   it('should NOT include activateFee when account is already activated', async () => {

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
@@ -66,6 +66,13 @@ describe('ExactGasFreeClientMechanism', () => {
     expect(payload.x402Version).toBe(2);
     expect(payload.payload.signature).toBe('0x' + 'ab'.repeat(65));
     expect(payload.extensions?.gasfreeAddress).toBe('TLCvf7MktLG7XkbJRyUwnvCeDnaEXYkcbC');
+
+    const [domain, _types, message] = mockSigner.signTypedData.mock.calls[0];
+    expect(String(domain.verifyingContract).startsWith('0x')).toBe(true);
+    expect(String(message.token).startsWith('0x')).toBe(true);
+    expect(String(message.serviceProvider).startsWith('0x')).toBe(true);
+    expect(String(message.user).startsWith('0x')).toBe(true);
+    expect(String(message.receiver).startsWith('0x')).toBe(true);
   });
 
   it('should adjust maxFee to protocol minimum', async () => {

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -13,7 +13,26 @@ import {
 } from '../index.js';
 import { GASFREE_TYPES, GasFreeAPIClient } from '../utils/gasfree.js';
 import { findByAddress } from '../tokens.js';
-import { TronAddressConverter } from '../address.js';
+import { TronAddressConverter, ZERO_ADDRESS_HEX } from '../address.js';
+
+function requireEvmAddress(
+  raw: unknown,
+  fieldName: string,
+  converter: TronAddressConverter
+): string {
+  if (raw === null || raw === undefined) {
+    throw new Error(`GasFree TIP-712: address field "${fieldName}" is null or undefined`);
+  }
+
+  const converted = converter.toEvmFormat(String(raw));
+  if (converted === ZERO_ADDRESS_HEX) {
+    throw new Error(
+      `GasFree TIP-712: could not convert "${fieldName}" value "${raw}" to EVM format`
+    );
+  }
+
+  return converted;
+}
 
 export class ExactGasFreeClientMechanism implements ClientMechanism {
   private signer: ClientSigner;
@@ -136,14 +155,26 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
 
     const signingDomain = {
       ...domain,
-      verifyingContract: addressConverter.toEvmFormat(String(domain.verifyingContract)),
+      verifyingContract: requireEvmAddress(
+        domain.verifyingContract,
+        'verifyingContract',
+        addressConverter
+      ),
     };
     const signingMessage = {
       ...message,
-      token: addressConverter.toEvmFormat(String(message.token)),
-      serviceProvider: addressConverter.toEvmFormat(String(message.serviceProvider)),
-      user: addressConverter.toEvmFormat(String(message.user)),
-      receiver: addressConverter.toEvmFormat(String(message.receiver)),
+      // Explicitly convert known address fields to EVM 0x format.
+      // Do not use convertMessageAddresses() here — the message also contains
+      // numeric fields whose string representations should not be treated
+      // as addresses.
+      token: requireEvmAddress(message.token, 'token', addressConverter),
+      serviceProvider: requireEvmAddress(
+        message.serviceProvider,
+        'serviceProvider',
+        addressConverter
+      ),
+      user: requireEvmAddress(message.user, 'user', addressConverter),
+      receiver: requireEvmAddress(message.receiver, 'receiver', addressConverter),
     };
 
     const signature = await this.signer.signTypedData(

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -13,6 +13,7 @@ import {
 } from '../index.js';
 import { GASFREE_TYPES, GasFreeAPIClient } from '../utils/gasfree.js';
 import { findByAddress } from '../tokens.js';
+import { TronAddressConverter } from '../address.js';
 
 export class ExactGasFreeClientMechanism implements ClientMechanism {
   private signer: ClientSigner;
@@ -118,6 +119,7 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
     const deadline = (extensions as any)?.paymentPermitContext?.meta?.validBefore || Math.floor(Date.now() / 1000) + 3600;
     
     const gasFree = new TronGasFree({ chainId });
+    const addressConverter = new TronAddressConverter();
 
     // 5. Sign TIP-712 typed data
     const { domain, types, message } = gasFree.assembleGasFreeTransactionJson({
@@ -131,8 +133,25 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
       version: '1',
       nonce: accountInfo.nonce.toString(),
     });
-    
-    const signature = await this.signer.signTypedData(domain, types, message, GASFREE_PRIMARY_TYPE);
+
+    const signingDomain = {
+      ...domain,
+      verifyingContract: addressConverter.toEvmFormat(String(domain.verifyingContract)),
+    };
+    const signingMessage = {
+      ...message,
+      token: addressConverter.toEvmFormat(String(message.token)),
+      serviceProvider: addressConverter.toEvmFormat(String(message.serviceProvider)),
+      user: addressConverter.toEvmFormat(String(message.user)),
+      receiver: addressConverter.toEvmFormat(String(message.receiver)),
+    };
+
+    const signature = await this.signer.signTypedData(
+      signingDomain,
+      types,
+      signingMessage,
+      GASFREE_PRIMARY_TYPE
+    );
 
     // 6. Build PaymentPermit structure
     const paymentPermit: PaymentPermit = {


### PR DESCRIPTION
## Summary
- Fix GasFree TIP-712 signing to convert address fields to EVM 0x format in TypeScript
- Add tests to assert EVM-formatted addresses for GasFree signing (TS + Python)
- Bump Python/TypeScript versions to 0.5.1 and update changelog/release notes
- Normalize GasFree client test addresses to valid TRON Base58 format

## Testing
- pnpm -C typescript/packages/x402 test
- .venv/bin/python -m pytest python/x402/tests/exact/test_gasfree_client.py
