### PR TITLE
Fix GasFree balance selection fallback

### DIFF
--- a/python/x402/src/bankofai/x402/clients/policies.py
+++ b/python/x402/src/bankofai/x402/clients/policies.py
@@ -59,15 +59,32 @@ class SufficientBalancePolicy:
                 affordable.append(req)
                 continue
 
+            balance_address = None
+            extra_needed_override = None
+            mechanism = self._client.resolve_mechanism(req.scheme, req.network)
+            if mechanism is not None and hasattr(mechanism, "resolve_balance_check_context"):
+                try:
+                    context = await mechanism.resolve_balance_check_context(req)
+                    if context:
+                        balance_address = context.get("address")
+                        extra_needed_override = context.get("extra_needed")
+                except Exception:
+                    # Failed to resolve scheme-specific balance context; fallback to signer address.
+                    pass
+
             try:
-                balance = await signer.check_balance(req.asset, req.network)
+                balance = await signer.check_balance(
+                    req.asset, req.network, address=balance_address
+                )
             except Exception:
                 # Signer cannot query this network; keep the requirement.
                 affordable.append(req)
                 continue
 
             needed = int(req.amount)
-            if hasattr(req, "extra") and req.extra and hasattr(req.extra, "fee"):
+            if extra_needed_override is not None:
+                needed += int(extra_needed_override)
+            elif hasattr(req, "extra") and req.extra and hasattr(req.extra, "fee"):
                 fee = req.extra.fee
                 if fee and hasattr(fee, "fee_amount"):
                     needed += int(fee.fee_amount)

--- a/python/x402/src/bankofai/x402/clients/x402_client.py
+++ b/python/x402/src/bankofai/x402/clients/x402_client.py
@@ -29,6 +29,12 @@ class ClientMechanism(Protocol):
         """Return the signer used by this mechanism, or None."""
         ...
 
+    async def resolve_balance_check_context(
+        self, requirements: PaymentRequirements
+    ) -> dict[str, int | str] | None:
+        """Resolve a scheme-specific balance check context."""
+        ...
+
     async def create_payment_payload(
         self,
         requirements: PaymentRequirements,
@@ -122,6 +128,10 @@ class X402Client:
         if mechanism is not None and hasattr(mechanism, "get_signer"):
             return mechanism.get_signer()
         return None
+
+    def resolve_mechanism(self, scheme: str, network: str) -> ClientMechanism | None:
+        """Resolve a mechanism from registered mechanisms for the given scheme+network."""
+        return self._find_mechanism(scheme, network)
 
     def register(self, network_pattern: str, mechanism: ClientMechanism) -> "X402Client":
         """

--- a/python/x402/src/bankofai/x402/mechanisms/_base/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/_base/client.py
@@ -31,6 +31,18 @@ class ClientMechanism(ABC):
         """
         return None
 
+    async def resolve_balance_check_context(
+        self,
+        requirements: PaymentRequirements,
+    ) -> dict[str, int | str] | None:
+        """Resolve a scheme-specific balance check context.
+
+        Return a dict with:
+        - address: address to check balance against
+        - extra_needed: extra amount (e.g. fees) to add to required amount
+        """
+        return None
+
     @abstractmethod
     async def create_payment_payload(
         self,

--- a/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
@@ -58,6 +58,37 @@ class ExactGasFreeClientMechanism(ClientMechanism):
     def get_signer(self) -> Any:
         return self._signer
 
+    async def resolve_balance_check_context(
+        self, requirements: PaymentRequirements
+    ) -> dict[str, int | str] | None:
+        network = requirements.network
+        user_address = self._signer.get_address()
+        api_client = self._get_api_client(network)
+
+        account_info = await api_client.get_address_info(user_address)
+        gasfree_address = account_info.get("gasFreeAddress")
+        if not gasfree_address:
+            return None
+
+        is_active = account_info.get("active", False)
+        assets = account_info.get("assets", [])
+        transfer_fee = 0
+        activate_fee = 0
+        target_token = self._address_converter.normalize(requirements.asset)
+        for asset in assets:
+            if asset.get("tokenAddress") == target_token:
+                transfer_fee = int(asset.get("transferFee", 0))
+                activate_fee = int(asset.get("activateFee", 0))
+                break
+
+        fee_info = requirements.extra.fee if requirements.extra else None
+        facilitator_fee = int(fee_info.fee_amount or "0") if fee_info else 0
+        max_fee_val = max(transfer_fee, facilitator_fee)
+        if not is_active and activate_fee > 0:
+            max_fee_val += activate_fee
+
+        return {"address": gasfree_address, "extra_needed": max_fee_val}
+
     async def create_payment_payload(
         self,
         requirements: PaymentRequirements,

--- a/python/x402/tests/client/test_policies.py
+++ b/python/x402/tests/client/test_policies.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from bankofai.x402.clients import SufficientBalancePolicy, X402Client
+from bankofai.x402.types import FeeInfo, PaymentRequirements, PaymentRequirementsExtra
+
+
+class DummyMechanism:
+    def __init__(self, scheme: str, signer, context=None):
+        self._scheme = scheme
+        self._signer = signer
+        self._context = context
+
+    def scheme(self) -> str:
+        return self._scheme
+
+    def get_signer(self):
+        return self._signer
+
+    async def resolve_balance_check_context(self, requirements):
+        return self._context
+
+    async def create_payment_payload(self, requirements, resource, extensions=None):
+        raise RuntimeError("not used")
+
+
+@pytest.mark.asyncio
+async def test_sufficient_balance_policy_filters_gasfree_on_subaddress():
+    network = "tron:nile"
+    asset = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"
+    gasfree_address = "TLCvf7MktLG7XkbJRyUwnvCeDnaEXYkcbC"
+
+    async def gasfree_balance(_token, _network, address=None):
+        return 1100 if address == gasfree_address else 0
+
+    gasfree_signer = type("GasfreeSigner", (), {})()
+    gasfree_signer.check_balance = AsyncMock(side_effect=gasfree_balance)
+
+    exact_signer = type("ExactSigner", (), {})()
+    exact_signer.check_balance = AsyncMock(return_value=9999)
+
+    gasfree_mech = DummyMechanism(
+        "exact_gasfree",
+        gasfree_signer,
+        context={"address": gasfree_address, "extra_needed": 200},
+    )
+    exact_mech = DummyMechanism("exact", exact_signer)
+
+    client = X402Client()
+    client.register("tron:*", gasfree_mech)
+    client.register("tron:*", exact_mech)
+
+    policy = SufficientBalancePolicy(client)
+    requirements = [
+        PaymentRequirements(
+            scheme="exact_gasfree",
+            network=network,
+            amount="1000",
+            asset=asset,
+            payTo="TTestPayTo",
+            extra=PaymentRequirementsExtra(
+                fee=FeeInfo(feeTo="TTestFeeTo", feeAmount="1000")
+            ),
+        ),
+        PaymentRequirements(
+            scheme="exact",
+            network=network,
+            amount="500",
+            asset=asset,
+            payTo="TTestPayTo",
+        ),
+    ]
+
+    result = await policy.apply(requirements)
+
+    assert [r.scheme for r in result] == ["exact"]
+    gasfree_signer.check_balance.assert_any_call(
+        asset, network, address=gasfree_address
+    )
+
+
+@pytest.mark.asyncio
+async def test_sufficient_balance_policy_uses_extra_needed_override():
+    network = "tron:nile"
+    asset = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"
+    gasfree_address = "TLCvf7MktLG7XkbJRyUwnvCeDnaEXYkcbC"
+
+    async def gasfree_balance(_token, _network, address=None):
+        return 1500 if address == gasfree_address else 0
+
+    gasfree_signer = type("GasfreeSigner", (), {})()
+    gasfree_signer.check_balance = AsyncMock(side_effect=gasfree_balance)
+
+    gasfree_mech = DummyMechanism(
+        "exact_gasfree",
+        gasfree_signer,
+        context={"address": gasfree_address, "extra_needed": 200},
+    )
+
+    client = X402Client()
+    client.register("tron:*", gasfree_mech)
+
+    policy = SufficientBalancePolicy(client)
+    requirements = [
+        PaymentRequirements(
+            scheme="exact_gasfree",
+            network=network,
+            amount="1000",
+            asset=asset,
+            payTo="TTestPayTo",
+            extra=PaymentRequirementsExtra(
+                fee=FeeInfo(feeTo="TTestFeeTo", feeAmount="1000")
+            ),
+        )
+    ]
+
+    result = await policy.apply(requirements)
+
+    assert [r.scheme for r in result] == ["exact_gasfree"]
+    gasfree_signer.check_balance.assert_any_call(
+        asset, network, address=gasfree_address
+    )

--- a/typescript/packages/x402/src/client/policies.test.ts
+++ b/typescript/packages/x402/src/client/policies.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { X402Client, SufficientBalancePolicy } from '../index.js';
+import type { PaymentRequirements } from '../index.js';
+
+describe('SufficientBalancePolicy (GasFree)', () => {
+  it('filters exact_gasfree when GasFree balance is insufficient and falls back', async () => {
+    const network = 'tron:nile';
+    const asset = 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf';
+    const gasfreeAddress = 'TLCvf7MktLG7XkbJRyUwnvCeDnaEXYkcbC';
+
+    const gasfreeSigner = {
+      checkBalance: vi.fn(async (_asset: string, _network: string, address?: string) => {
+        if (address === gasfreeAddress) return 1100n;
+        return 9999n;
+      }),
+    };
+
+    const exactSigner = {
+      checkBalance: vi.fn(async () => 9999n),
+    };
+
+    const gasfreeMechanism = {
+      scheme: () => 'exact_gasfree',
+      getSigner: () => gasfreeSigner,
+      resolveBalanceCheckContext: vi.fn().mockResolvedValue({
+        address: gasfreeAddress,
+        extraNeeded: 200n,
+      }),
+      createPaymentPayload: async () => {
+        throw new Error('not used');
+      },
+    };
+
+    const exactMechanism = {
+      scheme: () => 'exact',
+      getSigner: () => exactSigner,
+      createPaymentPayload: async () => {
+        throw new Error('not used');
+      },
+    };
+
+    const client = new X402Client();
+    client.register('tron:*', gasfreeMechanism as any);
+    client.register('tron:*', exactMechanism as any);
+
+    const policy = new SufficientBalancePolicy(client);
+    const requirements: PaymentRequirements[] = [
+      {
+        scheme: 'exact_gasfree',
+        network,
+        amount: '1000',
+        asset,
+        payTo: 'TTestPayTo',
+        extra: {
+          fee: { feeTo: 'TTestFeeTo', feeAmount: '1000' },
+        },
+      },
+      {
+        scheme: 'exact',
+        network,
+        amount: '500',
+        asset,
+        payTo: 'TTestPayTo',
+      },
+    ];
+
+    const result = await policy.apply(requirements);
+
+    expect(result.map((r) => r.scheme)).toEqual(['exact']);
+    expect(gasfreeSigner.checkBalance).toHaveBeenCalledWith(asset, network, gasfreeAddress);
+  });
+
+  it('uses scheme-specific extraNeeded instead of fee amount', async () => {
+    const network = 'tron:nile';
+    const asset = 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf';
+    const gasfreeAddress = 'TLCvf7MktLG7XkbJRyUwnvCeDnaEXYkcbC';
+
+    const gasfreeSigner = {
+      checkBalance: vi.fn(async (_asset: string, _network: string, address?: string) => {
+        if (address === gasfreeAddress) return 1500n;
+        return 0n;
+      }),
+    };
+
+    const gasfreeMechanism = {
+      scheme: () => 'exact_gasfree',
+      getSigner: () => gasfreeSigner,
+      resolveBalanceCheckContext: vi.fn().mockResolvedValue({
+        address: gasfreeAddress,
+        extraNeeded: 200n,
+      }),
+      createPaymentPayload: async () => {
+        throw new Error('not used');
+      },
+    };
+
+    const client = new X402Client();
+    client.register('tron:*', gasfreeMechanism as any);
+
+    const policy = new SufficientBalancePolicy(client);
+    const requirements: PaymentRequirements[] = [
+      {
+        scheme: 'exact_gasfree',
+        network,
+        amount: '1000',
+        asset,
+        payTo: 'TTestPayTo',
+        extra: {
+          fee: { feeTo: 'TTestFeeTo', feeAmount: '1000' },
+        },
+      },
+    ];
+
+    const result = await policy.apply(requirements);
+
+    expect(result.map((r) => r.scheme)).toEqual(['exact_gasfree']);
+    expect(gasfreeSigner.checkBalance).toHaveBeenCalledWith(asset, network, gasfreeAddress);
+  });
+});

--- a/typescript/packages/x402/src/client/policies.ts
+++ b/typescript/packages/x402/src/client/policies.ts
@@ -52,8 +52,24 @@ export class SufficientBalancePolicy implements PaymentPolicy {
       }
 
       let balance: bigint;
+      let extraNeededOverride: bigint | null = null;
+      let balanceAddress: string | undefined;
+      const mechanism = this.client.resolveMechanism(req.scheme, req.network);
+      if (mechanism?.resolveBalanceCheckContext) {
+        try {
+          const context = await mechanism.resolveBalanceCheckContext(req);
+          if (context?.address) {
+            balanceAddress = context.address;
+            if (typeof context.extraNeeded === 'bigint') {
+              extraNeededOverride = context.extraNeeded;
+            }
+          }
+        } catch {
+          // Failed to resolve scheme-specific balance context; fallback to signer address.
+        }
+      }
       try {
-        balance = await signer.checkBalance(req.asset, req.network);
+        balance = await signer.checkBalance(req.asset, req.network, balanceAddress);
       } catch {
         // Signer cannot query this network; keep the requirement.
         affordable.push(req);
@@ -61,7 +77,9 @@ export class SufficientBalancePolicy implements PaymentPolicy {
       }
 
       let needed = BigInt(req.amount);
-      if (req.extra?.fee?.feeAmount) {
+      if (extraNeededOverride !== null) {
+        needed += extraNeededOverride;
+      } else if (req.extra?.fee?.feeAmount) {
         needed += BigInt(req.extra.fee.feeAmount);
       }
       const decimals = getDecimals(req);

--- a/typescript/packages/x402/src/client/x402Client.ts
+++ b/typescript/packages/x402/src/client/x402Client.ts
@@ -25,6 +25,14 @@ export interface ClientMechanism {
    * Used by X402Client to auto-register balance-aware policies.
    */
   getSigner?(): ClientSigner;
+
+  /**
+   * Resolve a scheme-specific balance check context.
+   * When provided, policies can use the returned address and extra required amount.
+   */
+  resolveBalanceCheckContext?(
+    requirements: PaymentRequirements
+  ): Promise<{ address: string; extraNeeded?: bigint } | null>;
   
   /** Create payment payload */
   createPaymentPayload(
@@ -160,6 +168,13 @@ export class X402Client {
    */
   registerGasFree(signer: ClientSigner, clients: Record<string, GasFreeAPIClient> = {}): X402Client {
     return this.register('tron:*', new ExactGasFreeClientMechanism(signer, clients));
+  }
+
+  /**
+   * Resolve a mechanism instance for scheme+network.
+   */
+  resolveMechanism(scheme: string, network: string): ClientMechanism | null {
+    return this.findMechanism(scheme, network);
   }
 
   /**

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -55,6 +55,29 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
     return 'exact_gasfree';
   }
 
+  async resolveBalanceCheckContext(
+    requirements: PaymentRequirements
+  ): Promise<{ address: string; extraNeeded?: bigint } | null> {
+    const apiClient = this.getApiClient(requirements.network);
+    const userAddress = await this.signer.getAddress();
+    const accountInfo = await apiClient.getAddressInfo(userAddress);
+    const gasfreeAddress = accountInfo.gasFreeAddress;
+    if (!gasfreeAddress) {
+      return null;
+    }
+
+    const assetInfo = accountInfo.assets?.find((a: any) => a.tokenAddress === requirements.asset);
+    const transferFee = BigInt(assetInfo?.transferFee || '0');
+    const activateFee = BigInt(assetInfo?.activateFee || '0');
+    const facilitatorFee = BigInt(requirements.extra?.fee?.feeAmount || '0');
+    let maxFeeBig = transferFee > facilitatorFee ? transferFee : facilitatorFee;
+    if (!accountInfo.active && activateFee > 0n) {
+      maxFeeBig += activateFee;
+    }
+
+    return { address: gasfreeAddress, extraNeeded: maxFeeBig };
+  }
+
   async createPaymentPayload(
     requirements: PaymentRequirements,
     resource: string,


### PR DESCRIPTION
## Summary
- check GasFree subaddress balance during requirement filtering
- add scheme-specific balance context resolver
- add TS and Python tests for GasFree balance filtering

## Testing
- pnpm test (typescript/packages/x402)
- uv run pytest -q tests/client/test_policies.py (python/x402)
