### PR TITLE
fix gasfree deadline bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-03-27
+
+### Fixed
+- Clamp GasFree client deadlines to provider bounds (mainnet: 50–600s, nile/shasta: 50–3600s)
+- When above provider max, clamp down (never extend beyond max); when below min, fail fast
+
+### Added
+- Log when a GasFree deadline is clamped for easier diagnosis
+
 ## [0.5.2] - 2026-03-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.3] - 2026-03-27
 
 ### Fixed
-- Clamp GasFree client deadlines to provider bounds (mainnet: 50–600s, nile/shasta: 50–3600s)
+- Clamp GasFree client deadlines to provider bounds (mainnet: 50–600s, others: 50–3600s)
+- Add a 5s safety margin: +5s to min and −5s to max to absorb clock drift and network latency
 - When above provider max, clamp down (never extend beyond max); when below min, fail fast
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.3] - 2026-03-27
+## [0.5.4] - 2026-03-27
 
 ### Fixed
 - Clamp GasFree client deadlines to provider bounds (mainnet: 50–600s, others: 50–3600s)
 - Add a 5s safety margin: +5s to min and −5s to max to absorb clock drift and network latency
 - When above provider max, clamp down (never extend beyond max); when below min, fail fast
+- Align GasFree default deadline fallback to the per-network max to avoid noisy clamps
 
 ### Added
 - Log when a GasFree deadline is clamped for easier diagnosis
 
-## [0.5.2] - 2026-03-27
+## [0.5.3] - 2026-03-27
 
 ### Fixed
 - Align TRON mainnet GasFreeController address with GasFree SDK to prevent TIP-712 signature verification mismatches

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,13 @@
-# v0.5.2 - GasFree Mainnet Controller Align
+# v0.5.3 - GasFree Deadline Bounds
 
 Release date: March 27, 2026
 
 ## What's New
 
-- **Mainnet GasFreeController aligned**: Python config now matches the GasFree SDK-provided mainnet controller address to prevent signature verification mismatches.
-- **GasFree signing debug logs**: TypeScript GasFree client logs signer, domain, and message to aid troubleshooting.
+- **Deadline bounds enforced**: GasFree client clamps `deadline/validBefore` to provider limits.
+  - mainnet: 50–600s (with 5s safety margin on max)
+  - nile/shasta: 50–3600s (with 5s safety margin on max)
+- **Clamp logging**: logs when the deadline is reduced to the provider max.
 
 ## Breaking Changes
 
@@ -13,5 +15,11 @@ None.
 
 ## Affected SDKs
 
-- **Python**: `bankofai-x402==0.5.2`
-- **TypeScript**: `@bankofai/x402@0.5.2`
+- **Python**: `bankofai-x402==0.5.3`
+- **TypeScript**: `@bankofai/x402@0.5.3`
+
+## Previously Released (0.5.2)
+
+The following changes were released in 0.5.2 and are not new in 0.5.3:
+- Mainnet GasFreeController alignment
+- GasFree signing debug logs

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,8 +5,8 @@ Release date: March 27, 2026
 ## What's New
 
 - **Deadline bounds enforced**: GasFree client clamps `deadline/validBefore` to provider limits.
-  - mainnet: 50–600s (with 5s safety margin on max)
-  - nile/shasta: 50–3600s (with 5s safety margin on max)
+  - mainnet: 50–600s (with +5s min / −5s max safety margin)
+  - non-mainnet: 50–3600s (with +5s min / −5s max safety margin)
 - **Clamp logging**: logs when the deadline is reduced to the provider max.
 
 ## Breaking Changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# v0.5.3 - GasFree Deadline Bounds
+# v0.5.4 - GasFree Deadline Bounds (Refined)
 
 Release date: March 27, 2026
 
@@ -7,6 +7,7 @@ Release date: March 27, 2026
 - **Deadline bounds enforced**: GasFree client clamps `deadline/validBefore` to provider limits.
   - mainnet: 50–600s (with +5s min / −5s max safety margin)
   - non-mainnet: 50–3600s (with +5s min / −5s max safety margin)
+- **Cleaner defaults**: GasFree fallback deadline now uses the per-network max to avoid unnecessary clamp warnings.
 - **Clamp logging**: logs when the deadline is reduced to the provider max.
 
 ## Breaking Changes
@@ -15,11 +16,11 @@ None.
 
 ## Affected SDKs
 
-- **Python**: `bankofai-x402==0.5.3`
-- **TypeScript**: `@bankofai/x402@0.5.3`
+- **Python**: `bankofai-x402==0.5.4`
+- **TypeScript**: `@bankofai/x402@0.5.4`
 
-## Previously Released (0.5.2)
+## Previously Released (0.5.3)
 
-The following changes were released in 0.5.2 and are not new in 0.5.3:
-- Mainnet GasFreeController alignment
-- GasFree signing debug logs
+The following changes were released in 0.5.3 and are not new in 0.5.4:
+- Deadline bounds and safety margin enforcement
+- Clamp logging for out-of-range deadlines

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.5.2"
+version = "0.5.3"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.5.3"
+version = "0.5.4"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/src/bankofai/x402/__init__.py
+++ b/python/x402/src/bankofai/x402/__init__.py
@@ -37,7 +37,7 @@ from bankofai.x402.types import (
     VerifyResponse,
 )
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 __all__ = [
     "__version__",
     # Types

--- a/python/x402/src/bankofai/x402/__init__.py
+++ b/python/x402/src/bankofai/x402/__init__.py
@@ -37,7 +37,7 @@ from bankofai.x402.types import (
     VerifyResponse,
 )
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 __all__ = [
     "__version__",
     # Types

--- a/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
@@ -58,16 +58,16 @@ class ExactGasFreeClientMechanism(ClientMechanism):
     def get_signer(self) -> Any:
         return self._signer
 
-    def _clamp_deadline(self, network: str, deadline_seconds: int) -> int:
-        now = int(time.time())
+    def _get_deadline_bounds(self, network: str) -> tuple[int, int]:
         if network == "tron:mainnet":
             # GasFree mainnet bounds: >= 50s, <= 600s. We add 5s to min and subtract 5s from max.
-            min_delta = 55
-            max_delta = 595
-        else:
-            # Non-mainnet bounds: >= 50s, <= 3600s. We add 5s to min and subtract 5s from max.
-            min_delta = 55
-            max_delta = 3595
+            return 55, 595
+        # Non-mainnet bounds: >= 50s, <= 3600s. We add 5s to min and subtract 5s from max.
+        return 55, 3595
+
+    def _clamp_deadline(self, network: str, deadline_seconds: int) -> int:
+        now = int(time.time())
+        min_delta, max_delta = self._get_deadline_bounds(network)
 
         min_deadline = now + min_delta
         max_deadline = now + max_delta
@@ -170,9 +170,10 @@ class ExactGasFreeClientMechanism(ClientMechanism):
             if asset_balance < required_total:
                 raise InsufficientGasFreeBalance(gasfree_address, required_total, asset_balance)
 
+        _min_delta, max_delta = self._get_deadline_bounds(network)
         deadline_raw = (extensions or {}).get("paymentPermitContext", {}).get("meta", {}).get(
             "validBefore"
-        ) or int(time.time()) + 3600
+        ) or int(time.time()) + max_delta
         deadline = self._clamp_deadline(network, int(deadline_raw))
 
         self._logger.debug(f"[GASFREE] User Wallet: {user_address}")

--- a/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
@@ -76,8 +76,7 @@ class ExactGasFreeClientMechanism(ClientMechanism):
         max_deadline = now + max_delta
         if deadline_seconds < min_deadline:
             raise ValueError(
-                f"GasFree deadline too soon for {network}: "
-                f"{deadline_seconds} < {min_deadline}"
+                f"GasFree deadline too soon for {network}: {deadline_seconds} < {min_deadline}"
             )
         if deadline_seconds > max_deadline:
             self._logger.debug(

--- a/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
@@ -60,9 +60,6 @@ class ExactGasFreeClientMechanism(ClientMechanism):
 
     def _clamp_deadline(self, network: str, deadline_seconds: int) -> int:
         now = int(time.time())
-        min_delta = 0
-        max_delta = 2**31 - 1
-
         if network == "tron:mainnet":
             # GasFree mainnet bounds: >= 50s, <= 600s. We add 5s to min and subtract 5s from max.
             min_delta = 55
@@ -79,9 +76,11 @@ class ExactGasFreeClientMechanism(ClientMechanism):
                 f"GasFree deadline too soon for {network}: {deadline_seconds} < {min_deadline}"
             )
         if deadline_seconds > max_deadline:
-            self._logger.debug(
-                f"[GASFREE SIGN] deadline clamped: network={network} "
-                f"from={deadline_seconds} to={max_deadline}"
+            self._logger.warning(
+                "[GASFREE SIGN] deadline clamped: network=%s from=%d to=%d",
+                network,
+                deadline_seconds,
+                max_deadline,
             )
             return max_deadline
         return deadline_seconds

--- a/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
@@ -64,12 +64,12 @@ class ExactGasFreeClientMechanism(ClientMechanism):
         max_delta = 2**31 - 1
 
         if network == "tron:mainnet":
-            # GasFree mainnet bounds: >= 50s, <= 600s. We subtract 5s as a safety margin.
-            min_delta = 50
+            # GasFree mainnet bounds: >= 50s, <= 600s. We add 5s to min and subtract 5s from max.
+            min_delta = 55
             max_delta = 595
-        elif network in ("tron:nile", "tron:shasta"):
-            # GasFree testnets bounds: >= 50s, <= 3600s. We subtract 5s as a safety margin.
-            min_delta = 50
+        else:
+            # Non-mainnet bounds: >= 50s, <= 3600s. We add 5s to min and subtract 5s from max.
+            min_delta = 55
             max_delta = 3595
 
         min_deadline = now + min_delta

--- a/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
+++ b/python/x402/src/bankofai/x402/mechanisms/tron/exact_gasfree/client.py
@@ -58,6 +58,35 @@ class ExactGasFreeClientMechanism(ClientMechanism):
     def get_signer(self) -> Any:
         return self._signer
 
+    def _clamp_deadline(self, network: str, deadline_seconds: int) -> int:
+        now = int(time.time())
+        min_delta = 0
+        max_delta = 2**31 - 1
+
+        if network == "tron:mainnet":
+            # GasFree mainnet bounds: >= 50s, <= 600s. We subtract 5s as a safety margin.
+            min_delta = 50
+            max_delta = 595
+        elif network in ("tron:nile", "tron:shasta"):
+            # GasFree testnets bounds: >= 50s, <= 3600s. We subtract 5s as a safety margin.
+            min_delta = 50
+            max_delta = 3595
+
+        min_deadline = now + min_delta
+        max_deadline = now + max_delta
+        if deadline_seconds < min_deadline:
+            raise ValueError(
+                f"GasFree deadline too soon for {network}: "
+                f"{deadline_seconds} < {min_deadline}"
+            )
+        if deadline_seconds > max_deadline:
+            self._logger.debug(
+                f"[GASFREE SIGN] deadline clamped: network={network} "
+                f"from={deadline_seconds} to={max_deadline}"
+            )
+            return max_deadline
+        return deadline_seconds
+
     async def create_payment_payload(
         self,
         requirements: PaymentRequirements,
@@ -143,9 +172,10 @@ class ExactGasFreeClientMechanism(ClientMechanism):
             if asset_balance < required_total:
                 raise InsufficientGasFreeBalance(gasfree_address, required_total, asset_balance)
 
-        deadline = (extensions or {}).get("paymentPermitContext", {}).get("meta", {}).get(
+        deadline_raw = (extensions or {}).get("paymentPermitContext", {}).get("meta", {}).get(
             "validBefore"
         ) or int(time.time()) + 3600
+        deadline = self._clamp_deadline(network, int(deadline_raw))
 
         self._logger.debug(f"[GASFREE] User Wallet: {user_address}")
         self._logger.debug(f"[GASFREE] GasFree Address: {gasfree_address}")

--- a/python/x402/tests/exact/test_gasfree_client.py
+++ b/python/x402/tests/exact/test_gasfree_client.py
@@ -2,6 +2,7 @@
 Tests for ExactGasFreeClientMechanism.
 """
 
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,6 +14,34 @@ from bankofai.x402.types import FeeInfo, PaymentRequirements, PaymentRequirement
 USDT_ADDRESS = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"
 PROVIDER_ADDRESS = "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E"
 MERCHANT_ADDRESS = "THKbWd2g5aS9tY59xk8hp5xMnbE8m3B3E"
+
+
+def _make_gasfree_mechanism():
+    mech = ExactGasFreeClientMechanism.__new__(ExactGasFreeClientMechanism)
+    import logging
+
+    mech._logger = logging.getLogger("test")
+    return mech
+
+
+def test_gasfree_deadline_clamp_mainnet_and_testnet():
+    mech = _make_gasfree_mechanism()
+    now = int(time.time())
+
+    # Mainnet: clamp down to now + 595 when above max (600 - 5 safety margin)
+    result_mainnet = mech._clamp_deadline("tron:mainnet", now + 1000)
+    assert result_mainnet == now + 595
+
+    # Nile: clamp down to now + 3595 when above max (3600 - 5 safety margin)
+    result_nile = mech._clamp_deadline("tron:nile", now + 4000)
+    assert result_nile == now + 3595
+
+
+def test_gasfree_deadline_too_soon_raises():
+    mech = _make_gasfree_mechanism()
+    now = int(time.time())
+    with pytest.raises(ValueError, match="deadline too soon"):
+        mech._clamp_deadline("tron:mainnet", now + 10)
 
 
 @pytest.fixture

--- a/python/x402/tests/exact/test_gasfree_client.py
+++ b/python/x402/tests/exact/test_gasfree_client.py
@@ -24,8 +24,10 @@ def _make_gasfree_mechanism():
     return mech
 
 
-def test_gasfree_deadline_clamp_mainnet_and_testnet():
+def test_gasfree_deadline_clamp_mainnet_and_testnet(monkeypatch):
     mech = _make_gasfree_mechanism()
+    fixed_now = 1_700_000_000
+    monkeypatch.setattr(time, "time", lambda: fixed_now)
     now = int(time.time())
 
     # Mainnet: clamp down to now + 595 when above max (600 - 5 safety margin)
@@ -37,8 +39,10 @@ def test_gasfree_deadline_clamp_mainnet_and_testnet():
     assert now + 3594 <= result_nile <= now + 3596
 
 
-def test_gasfree_deadline_too_soon_raises():
+def test_gasfree_deadline_too_soon_raises(monkeypatch):
     mech = _make_gasfree_mechanism()
+    fixed_now = 1_700_000_000
+    monkeypatch.setattr(time, "time", lambda: fixed_now)
     now = int(time.time())
     with pytest.raises(ValueError, match="deadline too soon"):
         mech._clamp_deadline("tron:mainnet", now + 10)

--- a/python/x402/tests/exact/test_gasfree_client.py
+++ b/python/x402/tests/exact/test_gasfree_client.py
@@ -30,11 +30,11 @@ def test_gasfree_deadline_clamp_mainnet_and_testnet():
 
     # Mainnet: clamp down to now + 595 when above max (600 - 5 safety margin)
     result_mainnet = mech._clamp_deadline("tron:mainnet", now + 1000)
-    assert result_mainnet == now + 595
+    assert now + 594 <= result_mainnet <= now + 596
 
     # Nile: clamp down to now + 3595 when above max (3600 - 5 safety margin)
     result_nile = mech._clamp_deadline("tron:nile", now + 4000)
-    assert result_nile == now + 3595
+    assert now + 3594 <= result_nile <= now + 3596
 
 
 def test_gasfree_deadline_too_soon_raises():

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -4321,7 +4321,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -4321,7 +4321,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
@@ -424,6 +424,8 @@ describe('ExactGasFreeClientMechanism', () => {
   });
 
   it('should clamp deadline above max for mainnet and nile', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-27T00:00:00Z'));
     const now = Math.floor(Date.now() / 1000);
     const baseReq: PaymentRequirements = {
       scheme: 'exact_gasfree',
@@ -443,8 +445,7 @@ describe('ExactGasFreeClientMechanism', () => {
       'https://example.com/res',
       { paymentPermitContext: { meta: { validBefore: now + 2000 } } }
     );
-    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBeGreaterThanOrEqual(now + 594);
-    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBeLessThanOrEqual(now + 596);
+    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBe(now + 595);
 
     const nileClient = new ExactGasFreeClientMechanism(
       mockSigner as unknown as ClientSigner,
@@ -455,11 +456,14 @@ describe('ExactGasFreeClientMechanism', () => {
       'https://example.com/res',
       { paymentPermitContext: { meta: { validBefore: now + 5000 } } }
     );
-    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBeGreaterThanOrEqual(now + 3594);
-    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBeLessThanOrEqual(now + 3596);
+    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBe(now + 3595);
+
+    vi.useRealTimers();
   });
 
   it('should throw when deadline is too soon', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-27T00:00:00Z'));
     const now = Math.floor(Date.now() / 1000);
     const requirements: PaymentRequirements = {
       scheme: 'exact_gasfree',
@@ -479,5 +483,7 @@ describe('ExactGasFreeClientMechanism', () => {
         paymentPermitContext: { meta: { validBefore: now + 10 } },
       })
     ).rejects.toThrow('deadline too soon');
+
+    vi.useRealTimers();
   });
 });

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
@@ -443,7 +443,8 @@ describe('ExactGasFreeClientMechanism', () => {
       'https://example.com/res',
       { paymentPermitContext: { meta: { validBefore: now + 2000 } } }
     );
-    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBe(now + 595);
+    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBeGreaterThanOrEqual(now + 594);
+    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBeLessThanOrEqual(now + 596);
 
     const nileClient = new ExactGasFreeClientMechanism(
       mockSigner as unknown as ClientSigner,
@@ -454,7 +455,8 @@ describe('ExactGasFreeClientMechanism', () => {
       'https://example.com/res',
       { paymentPermitContext: { meta: { validBefore: now + 5000 } } }
     );
-    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBe(now + 3595);
+    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBeGreaterThanOrEqual(now + 3594);
+    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBeLessThanOrEqual(now + 3596);
   });
 
   it('should throw when deadline is too soon', async () => {

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.test.ts
@@ -422,4 +422,60 @@ describe('ExactGasFreeClientMechanism', () => {
     await expect(mechanism.createPaymentPayload(requirements, 'url'))
       .rejects.toThrow('GasFree is not configured for network: tron:mainnet');
   });
+
+  it('should clamp deadline above max for mainnet and nile', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const baseReq: PaymentRequirements = {
+      scheme: 'exact_gasfree',
+      network: 'tron:mainnet',
+      amount: '1000000',
+      asset: USDT_ADDRESS,
+      payTo: MOCK_ADDR,
+      extra: { fee: { feeTo: MOCK_ADDR, feeAmount: '0' } },
+    };
+
+    const mainnetClient = new ExactGasFreeClientMechanism(
+      mockSigner as unknown as ClientSigner,
+      { 'tron:mainnet': mockApiClient }
+    );
+    const mainnetPayload = await mainnetClient.createPaymentPayload(
+      baseReq,
+      'https://example.com/res',
+      { paymentPermitContext: { meta: { validBefore: now + 2000 } } }
+    );
+    expect(mainnetPayload.payload.paymentPermit?.meta.validBefore).toBe(now + 595);
+
+    const nileClient = new ExactGasFreeClientMechanism(
+      mockSigner as unknown as ClientSigner,
+      { 'tron:nile': mockApiClient }
+    );
+    const nilePayload = await nileClient.createPaymentPayload(
+      { ...baseReq, network: 'tron:nile' },
+      'https://example.com/res',
+      { paymentPermitContext: { meta: { validBefore: now + 5000 } } }
+    );
+    expect(nilePayload.payload.paymentPermit?.meta.validBefore).toBe(now + 3595);
+  });
+
+  it('should throw when deadline is too soon', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const requirements: PaymentRequirements = {
+      scheme: 'exact_gasfree',
+      network: 'tron:nile',
+      amount: '1000000',
+      asset: USDT_ADDRESS,
+      payTo: MOCK_ADDR,
+      extra: { fee: { feeTo: MOCK_ADDR, feeAmount: '0' } },
+    };
+
+    const client = new ExactGasFreeClientMechanism(
+      mockSigner as unknown as ClientSigner,
+      { 'tron:nile': mockApiClient }
+    );
+    await expect(
+      client.createPaymentPayload(requirements, 'https://example.com/res', {
+        paymentPermitContext: { meta: { validBefore: now + 10 } },
+      })
+    ).rejects.toThrow('deadline too soon');
+  });
 });

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -57,12 +57,12 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
     let maxDelta = Number.POSITIVE_INFINITY;
 
     if (network === 'tron:mainnet') {
-      // GasFree mainnet bounds: >= 50s, <= 600s. We subtract 5s as a safety margin.
-      minDelta = 50;
+      // GasFree mainnet bounds: >= 50s, <= 600s. We add 5s to min and subtract 5s from max.
+      minDelta = 55;
       maxDelta = 595;
-    } else if (network === 'tron:nile' || network === 'tron:shasta') {
-      // GasFree testnets bounds: >= 50s, <= 3600s. We subtract 5s as a safety margin.
-      minDelta = 50;
+    } else {
+      // Non-mainnet bounds: >= 50s, <= 3600s. We add 5s to min and subtract 5s from max.
+      minDelta = 55;
       maxDelta = 3595;
     }
 

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -74,7 +74,7 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
       );
     }
     if (deadlineSeconds > maxDeadline) {
-      console.debug(
+      console.warn(
         '[GASFREE SIGN] deadline clamped',
         { network, from: deadlineSeconds, to: maxDeadline }
       );

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -51,6 +51,38 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
     throw new Error(`GasFree is not configured for network: ${network}`);
   }
 
+  private clampDeadline(network: string, deadlineSeconds: number): number {
+    const now = Math.floor(Date.now() / 1000);
+    let minDelta = 0;
+    let maxDelta = Number.POSITIVE_INFINITY;
+
+    if (network === 'tron:mainnet') {
+      // GasFree mainnet bounds: >= 50s, <= 600s. We subtract 5s as a safety margin.
+      minDelta = 50;
+      maxDelta = 595;
+    } else if (network === 'tron:nile' || network === 'tron:shasta') {
+      // GasFree testnets bounds: >= 50s, <= 3600s. We subtract 5s as a safety margin.
+      minDelta = 50;
+      maxDelta = 3595;
+    }
+
+    const minDeadline = now + minDelta;
+    const maxDeadline = now + maxDelta;
+    if (deadlineSeconds < minDeadline) {
+      throw new Error(
+        `GasFree deadline too soon for ${network}: ${deadlineSeconds} < ${minDeadline}`
+      );
+    }
+    if (deadlineSeconds > maxDeadline) {
+      console.debug(
+        '[GASFREE SIGN] deadline clamped',
+        { network, from: deadlineSeconds, to: maxDeadline }
+      );
+      return maxDeadline;
+    }
+    return deadlineSeconds;
+  }
+
   scheme(): string {
     return 'exact_gasfree';
   }
@@ -135,7 +167,10 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
       }
     }
 
-    const deadline = (extensions as any)?.paymentPermitContext?.meta?.validBefore || Math.floor(Date.now() / 1000) + 3600;
+    const deadlineRaw =
+      (extensions as any)?.paymentPermitContext?.meta?.validBefore ||
+      Math.floor(Date.now() / 1000) + 3600;
+    const deadline = this.clampDeadline(requirements.network, Number(deadlineRaw));
     
     const gasFree = new TronGasFree({ chainId });
     const addressConverter = new TronAddressConverter();

--- a/typescript/packages/x402/src/mechanisms/exactGasfree.ts
+++ b/typescript/packages/x402/src/mechanisms/exactGasfree.ts
@@ -51,20 +51,18 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
     throw new Error(`GasFree is not configured for network: ${network}`);
   }
 
-  private clampDeadline(network: string, deadlineSeconds: number): number {
-    const now = Math.floor(Date.now() / 1000);
-    let minDelta = 0;
-    let maxDelta = Number.POSITIVE_INFINITY;
-
+  private getDeadlineBounds(network: string): { minDelta: number; maxDelta: number } {
     if (network === 'tron:mainnet') {
       // GasFree mainnet bounds: >= 50s, <= 600s. We add 5s to min and subtract 5s from max.
-      minDelta = 55;
-      maxDelta = 595;
-    } else {
-      // Non-mainnet bounds: >= 50s, <= 3600s. We add 5s to min and subtract 5s from max.
-      minDelta = 55;
-      maxDelta = 3595;
+      return { minDelta: 55, maxDelta: 595 };
     }
+    // Non-mainnet bounds: >= 50s, <= 3600s. We add 5s to min and subtract 5s from max.
+    return { minDelta: 55, maxDelta: 3595 };
+  }
+
+  private clampDeadline(network: string, deadlineSeconds: number): number {
+    const now = Math.floor(Date.now() / 1000);
+    const { minDelta, maxDelta } = this.getDeadlineBounds(network);
 
     const minDeadline = now + minDelta;
     const maxDeadline = now + maxDelta;
@@ -167,9 +165,10 @@ export class ExactGasFreeClientMechanism implements ClientMechanism {
       }
     }
 
+    const { maxDelta } = this.getDeadlineBounds(requirements.network);
     const deadlineRaw =
       (extensions as any)?.paymentPermitContext?.meta?.validBefore ||
-      Math.floor(Date.now() / 1000) + 3600;
+      Math.floor(Date.now() / 1000) + maxDelta;
     const deadline = this.clampDeadline(requirements.network, Number(deadlineRaw));
     
     const gasFree = new TronGasFree({ chainId });


### PR DESCRIPTION
## Summary
- Enforce GasFree deadline bounds on client signing (mainnet 50–600s, nile/shasta 50–3600s; 5s safety margin on max)
- Log only when deadline is clamped down to provider max
- Bump SDK versions to 0.5.3 and update CHANGELOG/RELEASE_NOTES