### PR TITLE
fix: handle null and error responses in GasFree API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle null `data` in GasFree status API responses that caused `AttributeError` / `TypeError` during settlement polling
 - Retry transient HTTP errors during `waitForSuccess` polling instead of crashing the settlement flow
+- Abort polling after `max_errors` (default: 3) consecutive failures to avoid silently retrying permanent errors until timeout
+- Reset error counter after each successful poll so only truly consecutive errors trigger abort
 - Explicit null guards on all GasFree API response `data` fields (`getAddressInfo`, `getProviders`, `submit`)
-- Use `is None` checks in Python for precision (avoids false positives on empty dicts)
+- Guard `submit` return value against missing `id` field
+- Fix variable shadowing in Python `submit` (`message` parameter shadowed by local)
+- Use `is None` / `== null` checks for precision (avoids false positives on falsy values)
 
 ### Changed
 - `GasFreeResponse<T>.data` typed as `T | null` in TypeScript to reflect actual API contract
 - `getStatus` / `get_status` return type widened to nullable
+- `waitForSuccess` / `wait_for_success` accepts `max_errors` / `maxErrors` parameter (default: 3)
 - Timeout error messages now include error count for better observability
 
 ## [0.5.4] - 2026-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2026-03-28
+
+### Fixed
+- Handle null `data` in GasFree status API responses that caused `AttributeError` / `TypeError` during settlement polling
+- Retry transient HTTP errors during `waitForSuccess` polling instead of crashing the settlement flow
+- Explicit null guards on all GasFree API response `data` fields (`getAddressInfo`, `getProviders`, `submit`)
+- Use `is None` checks in Python for precision (avoids false positives on empty dicts)
+
+### Changed
+- `GasFreeResponse<T>.data` typed as `T | null` in TypeScript to reflect actual API contract
+- `getStatus` / `get_status` return type widened to nullable
+- Timeout error messages now include error count for better observability
+
 ## [0.5.4] - 2026-03-27
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,13 +6,16 @@ Release date: March 28, 2026
 
 - **Settlement crash on null status data**: GasFree status API can return `{"code": 200, "data": null}` when polled immediately after submission. This caused `AttributeError` in Python / `TypeError` in TypeScript, failing the settlement even though the on-chain transaction succeeded.
 - **Transient HTTP errors crash polling loop**: `waitForSuccess` now catches transient errors (e.g. 500/503) during status polling and retries instead of aborting the settlement.
+- **Permanent errors retried until timeout**: Polling now aborts after `max_errors` (default: 3) consecutive failures, preventing silent 120s hangs on permanent errors like invalid traceId or auth failures.
 - **Silent null propagation**: `getAddressInfo`, `getProviders`, and `submit` previously returned `None`/`null` silently when the API responded with null data. They now throw explicit errors.
+- **Missing submit id guard**: `submit` now throws if the API returns data without an `id` field, instead of silently returning `None` typed as `str`.
 
 ## Improvements
 
+- **Consecutive error tracking**: Error counter resets after each successful poll, so only truly consecutive errors count toward the `max_errors` abort threshold.
 - **Timeout diagnostics**: Timeout error messages now include the number of errors encountered during polling for easier debugging.
 - **Type accuracy**: `GasFreeResponse<T>.data` typed as `T | null` in TypeScript; `get_status` return type widened to `Dict | None` in Python to reflect actual API behavior.
-- **Null check precision**: Python null guards use `is None` instead of `not data` to avoid false positives on empty dicts.
+- **Null check precision**: Uses `is None` / `== null` for null checks to avoid false positives on other falsy values.
 
 ## Breaking Changes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,18 @@
-# v0.5.4 - GasFree Deadline Bounds (Refined)
+# v0.5.5 - GasFree Null Response Handling
 
-Release date: March 27, 2026
+Release date: March 28, 2026
 
-## What's New
+## Fixes
 
-- **Deadline bounds enforced**: GasFree client clamps `deadline/validBefore` to provider limits.
-  - mainnet: 50–600s (with +5s min / −5s max safety margin)
-  - non-mainnet: 50–3600s (with +5s min / −5s max safety margin)
-- **Cleaner defaults**: GasFree fallback deadline now uses the per-network max to avoid unnecessary clamp warnings.
-- **Clamp logging**: logs when the deadline is reduced to the provider max.
+- **Settlement crash on null status data**: GasFree status API can return `{"code": 200, "data": null}` when polled immediately after submission. This caused `AttributeError` in Python / `TypeError` in TypeScript, failing the settlement even though the on-chain transaction succeeded.
+- **Transient HTTP errors crash polling loop**: `waitForSuccess` now catches transient errors (e.g. 500/503) during status polling and retries instead of aborting the settlement.
+- **Silent null propagation**: `getAddressInfo`, `getProviders`, and `submit` previously returned `None`/`null` silently when the API responded with null data. They now throw explicit errors.
+
+## Improvements
+
+- **Timeout diagnostics**: Timeout error messages now include the number of errors encountered during polling for easier debugging.
+- **Type accuracy**: `GasFreeResponse<T>.data` typed as `T | null` in TypeScript; `get_status` return type widened to `Dict | None` in Python to reflect actual API behavior.
+- **Null check precision**: Python null guards use `is None` instead of `not data` to avoid false positives on empty dicts.
 
 ## Breaking Changes
 
@@ -16,11 +20,5 @@ None.
 
 ## Affected SDKs
 
-- **Python**: `bankofai-x402==0.5.4`
-- **TypeScript**: `@bankofai/x402@0.5.4`
-
-## Previously Released (0.5.3)
-
-The following changes were released in 0.5.3 and are not new in 0.5.4:
-- Deadline bounds and safety margin enforcement
-- Clamp logging for out-of-range deadlines
+- **Python**: `bankofai-x402==0.5.5`
+- **TypeScript**: `@bankofai/x402@0.5.5`

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.5.4"
+version = "0.5.5"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/src/bankofai/x402/__init__.py
+++ b/python/x402/src/bankofai/x402/__init__.py
@@ -37,7 +37,7 @@ from bankofai.x402.types import (
     VerifyResponse,
 )
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 __all__ = [
     "__version__",
     # Types

--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -108,7 +108,7 @@ class GasFreeAPIClient:
                     message = result.get("message") or result.get("reason")
                     raise RuntimeError(f"API business error: {message} - Body: {response.text}")
                 data = result.get("data")
-                if not data:
+                if data is None:
                     raise RuntimeError(f"GasFree API returned null data for address {user}")
                 return data
             except Exception as e:
@@ -134,7 +134,7 @@ class GasFreeAPIClient:
                         f"API business error: {result.get('message') or result.get('reason')}"
                     )
                 data = result.get("data")
-                if not data:
+                if data is None:
                     raise RuntimeError("GasFree config API returned null data")
                 return data.get("providers", [])
             except Exception as e:
@@ -182,13 +182,18 @@ class GasFreeAPIClient:
     ) -> Dict[str, Any]:
         """Wait for a GasFree transaction to reach a terminal state or ON_CHAIN state"""
         start_time = time.time()
+        error_count = 0
         logger.info(f"Start polling for GasFree transaction {trace_id} (timeout={timeout}s)...")
 
         while time.time() - start_time < timeout:
             try:
                 status_data = await self.get_status(trace_id)
             except Exception as e:
-                logger.warning(f"GasFree status poll failed for {trace_id}: {e}, retrying...")
+                error_count += 1
+                logger.warning(
+                    f"GasFree status poll failed for {trace_id}"
+                    f" (error #{error_count}): {e}, retrying..."
+                )
                 await asyncio.sleep(poll_interval)
                 continue
             if not status_data:
@@ -213,7 +218,10 @@ class GasFreeAPIClient:
 
             await asyncio.sleep(poll_interval)
 
-        raise TimeoutError(f"GasFree transaction {trace_id} timed out after {timeout}s")
+        raise TimeoutError(
+            f"GasFree transaction {trace_id} timed out after {timeout}s"
+            f" ({error_count} errors encountered)"
+        )
 
     async def submit(self, domain: Dict[str, Any], message: Dict[str, Any], signature: str) -> str:
         """Submit a signed GasFree transaction to the official relayer"""
@@ -246,7 +254,7 @@ class GasFreeAPIClient:
                     message = result.get("message") or result.get("reason")
                     raise RuntimeError(f"API business error: {message} - Body: {response.text}")
                 data = result.get("data")
-                if not data:
+                if data is None:
                     raise RuntimeError("GasFree submit API returned null data")
                 return data.get("id")  # Returns traceId
             except Exception as e:

--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -105,8 +105,8 @@ class GasFreeAPIClient:
                     response.raise_for_status()
                 result = response.json()
                 if result.get("code") != 200:
-                    message = result.get("message") or result.get("reason")
-                    raise RuntimeError(f"API business error: {message} - Body: {response.text}")
+                    err_msg = result.get("message") or result.get("reason")
+                    raise RuntimeError(f"API business error: {err_msg} - Body: {response.text}")
                 data = result.get("data")
                 if data is None:
                     raise RuntimeError(f"GasFree API returned null data for address {user}")
@@ -192,6 +192,7 @@ class GasFreeAPIClient:
         while time.time() - start_time < timeout:
             try:
                 status_data = await self.get_status(trace_id)
+                error_count = 0  # reset on successful poll
             except Exception as e:
                 error_count += 1
                 logger.warning(
@@ -259,12 +260,15 @@ class GasFreeAPIClient:
                     response.raise_for_status()
                 result = response.json()
                 if result.get("code") != 200:
-                    message = result.get("message") or result.get("reason")
-                    raise RuntimeError(f"API business error: {message} - Body: {response.text}")
+                    err_msg = result.get("message") or result.get("reason")
+                    raise RuntimeError(f"API business error: {err_msg} - Body: {response.text}")
                 data = result.get("data")
                 if data is None:
                     raise RuntimeError("GasFree submit API returned null data")
-                return data.get("id")  # Returns traceId
+                trace_id = data.get("id")
+                if not trace_id:
+                    raise RuntimeError("GasFree submit API returned data without 'id' field")
+                return trace_id
             except Exception as e:
                 if isinstance(e, httpx.HTTPStatusError):
                     logger.error(f"HTTP Status Error Body: {e.response.text}")

--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -107,7 +107,10 @@ class GasFreeAPIClient:
                 if result.get("code") != 200:
                     message = result.get("message") or result.get("reason")
                     raise RuntimeError(f"API business error: {message} - Body: {response.text}")
-                return result.get("data", {})
+                data = result.get("data")
+                if not data:
+                    raise RuntimeError(f"GasFree API returned null data for address {user}")
+                return data
             except Exception as e:
                 if isinstance(e, httpx.HTTPStatusError):
                     logger.error(f"HTTP Status Error Body: {e.response.text}")
@@ -130,7 +133,9 @@ class GasFreeAPIClient:
                     raise RuntimeError(
                         f"API business error: {result.get('message') or result.get('reason')}"
                     )
-                data = result.get("data", {})
+                data = result.get("data")
+                if not data:
+                    raise RuntimeError("GasFree config API returned null data")
                 return data.get("providers", [])
             except Exception as e:
                 logger.error(f"Failed to get providers from GasFree API: {e}")
@@ -145,8 +150,11 @@ class GasFreeAPIClient:
             logger.warning(f"Failed to get nonce from GasFree API: {e}. Defaulting to 0.")
             return 0
 
-    async def get_status(self, trace_id: str) -> Dict[str, Any]:
-        """Get status of a submitted GasFree transaction"""
+    async def get_status(self, trace_id: str) -> Dict[str, Any] | None:
+        """Get status of a submitted GasFree transaction.
+
+        Returns None if the API returned null data (e.g. status not yet available).
+        """
         path = f"/api/v1/gasfree/{trace_id}"
         async with httpx.AsyncClient() as client:
             url = f"{self.base_url}{path}"
@@ -161,8 +169,9 @@ class GasFreeAPIClient:
                     raise RuntimeError(
                         f"API business error: {result.get('message') or result.get('reason')}"
                     )
-                data = result.get("data", {})
-                logger.info(f"GasFree Status Response for {trace_id}: {json.dumps(data)}")
+                data = result.get("data")
+                if data:
+                    logger.info(f"GasFree Status Response for {trace_id}: {json.dumps(data)}")
                 return data
             except Exception as e:
                 logger.error(f"Failed to get GasFree transaction status: {e}")
@@ -176,7 +185,16 @@ class GasFreeAPIClient:
         logger.info(f"Start polling for GasFree transaction {trace_id} (timeout={timeout}s)...")
 
         while time.time() - start_time < timeout:
-            status_data = await self.get_status(trace_id)
+            try:
+                status_data = await self.get_status(trace_id)
+            except Exception as e:
+                logger.warning(f"GasFree status poll failed for {trace_id}: {e}, retrying...")
+                await asyncio.sleep(poll_interval)
+                continue
+            if not status_data:
+                logger.debug(f"GasFree transaction {trace_id} status not yet available, waiting...")
+                await asyncio.sleep(poll_interval)
+                continue
             state = (status_data.get("state") or "").upper()
             txn_state = (status_data.get("txnState") or "").upper()
 
@@ -227,7 +245,9 @@ class GasFreeAPIClient:
                 if result.get("code") != 200:
                     message = result.get("message") or result.get("reason")
                     raise RuntimeError(f"API business error: {message} - Body: {response.text}")
-                data = result.get("data", {})
+                data = result.get("data")
+                if not data:
+                    raise RuntimeError("GasFree submit API returned null data")
                 return data.get("id")  # Returns traceId
             except Exception as e:
                 if isinstance(e, httpx.HTTPStatusError):

--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -170,7 +170,7 @@ class GasFreeAPIClient:
                         f"API business error: {result.get('message') or result.get('reason')}"
                     )
                 data = result.get("data")
-                if data:
+                if data is not None:
                     logger.info(f"GasFree Status Response for {trace_id}: {json.dumps(data)}")
                 return data
             except Exception as e:
@@ -178,7 +178,11 @@ class GasFreeAPIClient:
                 raise
 
     async def wait_for_success(
-        self, trace_id: str, timeout: int = 120, poll_interval: int = 5
+        self,
+        trace_id: str,
+        timeout: int = 120,
+        poll_interval: int = 5,
+        max_errors: int = 3,
     ) -> Dict[str, Any]:
         """Wait for a GasFree transaction to reach a terminal state or ON_CHAIN state"""
         start_time = time.time()
@@ -194,6 +198,10 @@ class GasFreeAPIClient:
                     f"GasFree status poll failed for {trace_id}"
                     f" (error #{error_count}): {e}, retrying..."
                 )
+                if error_count >= max_errors:
+                    raise RuntimeError(
+                        f"GasFree status polling aborted after {error_count} consecutive errors"
+                    ) from e
                 await asyncio.sleep(poll_interval)
                 continue
             if not status_data:

--- a/python/x402/tests/utils/test_gasfree_utils.py
+++ b/python/x402/tests/utils/test_gasfree_utils.py
@@ -118,6 +118,71 @@ class TestGasFreeAPIClient:
         assert result["state"] == "SUCCEED"
         assert call_count == 2
 
+    @pytest.mark.anyio
+    async def test_wait_for_success_aborts_after_max_errors(self):
+        client = GasFreeAPIClient("https://api.example.com")
+
+        async def mock_get_status(trace_id):
+            raise RuntimeError("persistent error")
+
+        client.get_status = mock_get_status
+        with pytest.raises(RuntimeError, match="aborted after 2 consecutive errors"):
+            await client.wait_for_success("trace-123", timeout=5, poll_interval=0.1, max_errors=2)
+
+    @pytest.mark.anyio
+    async def test_get_address_info_raises_on_null_data(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        mock_response = {"code": 200, "data": None}
+
+        with patch("httpx.AsyncClient.get") as mock_get:
+            mock_get.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: mock_response,
+                raise_for_status=lambda: None,
+            )
+            with pytest.raises(RuntimeError, match="null data"):
+                await client.get_address_info("0x123")
+
+    @pytest.mark.anyio
+    async def test_get_providers_raises_on_null_data(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        mock_response = {"code": 200, "data": None}
+
+        with patch("httpx.AsyncClient.get") as mock_get:
+            mock_get.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: mock_response,
+                raise_for_status=lambda: None,
+            )
+            with pytest.raises(RuntimeError, match="null data"):
+                await client.get_providers()
+
+    @pytest.mark.anyio
+    async def test_submit_raises_on_null_data(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        mock_response = {"code": 200, "data": None}
+
+        message = {
+            "token": "0xtoken",
+            "serviceProvider": "0xprovider",
+            "user": "0xuser",
+            "receiver": "0xreceiver",
+            "value": "100",
+            "maxFee": "10",
+            "deadline": 1000,
+            "version": 1,
+            "nonce": 1,
+        }
+
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: mock_response,
+                raise_for_status=lambda: None,
+            )
+            with pytest.raises(RuntimeError, match="null data"):
+                await client.submit(domain={}, message=message, signature="0xabc")
+
 
 def test_get_gasfree_domain():
     domain = get_gasfree_domain(1, "THKbWd2g5aS9tY59xk8hp5xMnbE8m3B3E")

--- a/python/x402/tests/utils/test_gasfree_utils.py
+++ b/python/x402/tests/utils/test_gasfree_utils.py
@@ -83,6 +83,25 @@ class TestGasFreeAPIClient:
         assert trace_id == "trace-123"
 
 
+    @pytest.mark.anyio
+    async def test_wait_for_success_handles_null_status_data(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        call_count = 0
+
+        async def mock_get_status(trace_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None  # GasFree API returns {"code": 200, "data": null}
+            return {"state": "SUCCEED", "txnHash": "0xhash123"}
+
+        client.get_status = mock_get_status
+        result = await client.wait_for_success("trace-123", timeout=5, poll_interval=0.1)
+
+        assert result["state"] == "SUCCEED"
+        assert call_count == 2
+
+
 def test_get_gasfree_domain():
     domain = get_gasfree_domain(1, "THKbWd2g5aS9tY59xk8hp5xMnbE8m3B3E")
     assert domain["name"] == "GasFreeController"

--- a/python/x402/tests/utils/test_gasfree_utils.py
+++ b/python/x402/tests/utils/test_gasfree_utils.py
@@ -130,6 +130,29 @@ class TestGasFreeAPIClient:
             await client.wait_for_success("trace-123", timeout=5, poll_interval=0.1, max_errors=2)
 
     @pytest.mark.anyio
+    async def test_wait_for_success_resets_error_count_after_success(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        call_count = 0
+
+        async def mock_get_status(trace_id):
+            nonlocal call_count
+            call_count += 1
+            # fail, succeed (WAITING), fail, fail → should NOT abort at max_errors=2
+            if call_count in (1, 3, 4):
+                raise RuntimeError("transient error")
+            if call_count == 2:
+                return {"state": "WAITING"}
+            return {"state": "SUCCEED", "txnHash": "0xhash"}
+
+        client.get_status = mock_get_status
+        result = await client.wait_for_success(
+            "trace-123", timeout=5, poll_interval=0.1, max_errors=3
+        )
+
+        assert result["state"] == "SUCCEED"
+        assert call_count == 5
+
+    @pytest.mark.anyio
     async def test_get_address_info_raises_on_null_data(self):
         client = GasFreeAPIClient("https://api.example.com")
         mock_response = {"code": 200, "data": None}
@@ -181,6 +204,32 @@ class TestGasFreeAPIClient:
                 raise_for_status=lambda: None,
             )
             with pytest.raises(RuntimeError, match="null data"):
+                await client.submit(domain={}, message=message, signature="0xabc")
+
+    @pytest.mark.anyio
+    async def test_submit_raises_on_missing_id(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        mock_response = {"code": 200, "data": {"state": "WAITING"}}
+
+        message = {
+            "token": "0xtoken",
+            "serviceProvider": "0xprovider",
+            "user": "0xuser",
+            "receiver": "0xreceiver",
+            "value": "100",
+            "maxFee": "10",
+            "deadline": 1000,
+            "version": 1,
+            "nonce": 1,
+        }
+
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value = AsyncMock(
+                status_code=200,
+                json=lambda: mock_response,
+                raise_for_status=lambda: None,
+            )
+            with pytest.raises(RuntimeError, match="without 'id' field"):
                 await client.submit(domain={}, message=message, signature="0xabc")
 
 

--- a/python/x402/tests/utils/test_gasfree_utils.py
+++ b/python/x402/tests/utils/test_gasfree_utils.py
@@ -82,7 +82,6 @@ class TestGasFreeAPIClient:
 
         assert trace_id == "trace-123"
 
-
     @pytest.mark.anyio
     async def test_wait_for_success_handles_null_status_data(self):
         client = GasFreeAPIClient("https://api.example.com")
@@ -93,6 +92,24 @@ class TestGasFreeAPIClient:
             call_count += 1
             if call_count == 1:
                 return None  # GasFree API returns {"code": 200, "data": null}
+            return {"state": "SUCCEED", "txnHash": "0xhash123"}
+
+        client.get_status = mock_get_status
+        result = await client.wait_for_success("trace-123", timeout=5, poll_interval=0.1)
+
+        assert result["state"] == "SUCCEED"
+        assert call_count == 2
+
+    @pytest.mark.anyio
+    async def test_wait_for_success_retries_on_transient_error(self):
+        client = GasFreeAPIClient("https://api.example.com")
+        call_count = 0
+
+        async def mock_get_status(trace_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("transient network error")
             return {"state": "SUCCEED", "txnHash": "0xhash123"}
 
         client.get_status = mock_get_status

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -4321,7 +4321,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/src/utils/gasfree.test.ts
+++ b/typescript/packages/x402/src/utils/gasfree.test.ts
@@ -89,7 +89,8 @@ describe('GasFreeAPIClient', () => {
     });
 
     const status = await client.getStatus('trace-123');
-    expect(status.state).toBe('SUCCEED');
+    expect(status).not.toBeNull();
+    expect(status!.state).toBe('SUCCEED');
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/gasfree/trace-123'),
       expect.objectContaining({
@@ -124,6 +125,33 @@ describe('GasFreeAPIClient', () => {
         return {
           ok: true,
           text: async () => JSON.stringify({ code: 200, data: null }),
+        };
+      }
+      // Second poll returns success
+      return {
+        ok: true,
+        text: async () => JSON.stringify({
+          code: 200,
+          data: { id: 'trace-123', state: 'SUCCEED', txnHash: '0xabc' },
+        }),
+      };
+    });
+
+    const result = await client.waitForSuccess('trace-123', 5000, 100);
+    expect(result.state).toBe('SUCCEED');
+    expect(callCount).toBe(2);
+  });
+
+  it('should retry on transient error in waitForSuccess', async () => {
+    let callCount = 0;
+    (fetch as any).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // First poll throws a transient network error
+        return {
+          ok: false,
+          status: 503,
+          text: async () => 'Service Unavailable',
         };
       }
       // Second poll returns success

--- a/typescript/packages/x402/src/utils/gasfree.test.ts
+++ b/typescript/packages/x402/src/utils/gasfree.test.ts
@@ -169,6 +169,53 @@ describe('GasFreeAPIClient', () => {
     expect(callCount).toBe(2);
   });
 
+  it('should abort polling after max consecutive errors', async () => {
+    (fetch as any).mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    }));
+
+    await expect(client.waitForSuccess('trace-123', 10000, 100, 2))
+      .rejects.toThrow('aborted after 2 consecutive errors');
+  });
+
+  it('should throw on null data from getAddressInfo', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ code: 200, data: null }),
+    });
+
+    await expect(client.getAddressInfo('0x123'))
+      .rejects.toThrow('null data');
+  });
+
+  it('should throw on null data from getProviders', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ code: 200, data: null }),
+    });
+
+    await expect(client.getProviders())
+      .rejects.toThrow('null data');
+  });
+
+  it('should throw on null data from submit', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ code: 200, data: null }),
+    });
+
+    const message = {
+      token: '0xtoken', serviceProvider: '0xprovider', user: '0xuser',
+      receiver: '0xreceiver', value: 100, maxFee: 10, deadline: 1000,
+      version: 1, nonce: 1,
+    };
+
+    await expect(client.submit({}, message, '0xabc'))
+      .rejects.toThrow('null data');
+  });
+
   it('should get nonce', async () => {
     vi.spyOn(client, 'getAddressInfo').mockResolvedValue({
       nonce: 42,

--- a/typescript/packages/x402/src/utils/gasfree.test.ts
+++ b/typescript/packages/x402/src/utils/gasfree.test.ts
@@ -115,6 +115,32 @@ describe('GasFreeAPIClient', () => {
     expect(result.state).toBe('SUCCEED');
   });
 
+  it('should handle null status data in waitForSuccess', async () => {
+    let callCount = 0;
+    (fetch as any).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // First poll returns null data
+        return {
+          ok: true,
+          text: async () => JSON.stringify({ code: 200, data: null }),
+        };
+      }
+      // Second poll returns success
+      return {
+        ok: true,
+        text: async () => JSON.stringify({
+          code: 200,
+          data: { id: 'trace-123', state: 'SUCCEED', txnHash: '0xabc' },
+        }),
+      };
+    });
+
+    const result = await client.waitForSuccess('trace-123', 5000, 100);
+    expect(result.state).toBe('SUCCEED');
+    expect(callCount).toBe(2);
+  });
+
   it('should get nonce', async () => {
     vi.spyOn(client, 'getAddressInfo').mockResolvedValue({
       nonce: 42,

--- a/typescript/packages/x402/src/utils/gasfree.test.ts
+++ b/typescript/packages/x402/src/utils/gasfree.test.ts
@@ -180,6 +180,39 @@ describe('GasFreeAPIClient', () => {
       .rejects.toThrow('aborted after 2 consecutive errors');
   });
 
+  it('should reset error count after successful poll', async () => {
+    let callCount = 0;
+    (fetch as any).mockImplementation(async () => {
+      callCount++;
+      // fail, succeed (WAITING), fail, fail → should NOT abort at maxErrors=2
+      // because the success in between resets the counter
+      if (callCount === 1 || callCount === 3 || callCount === 4) {
+        return { ok: false, status: 503, text: async () => 'Service Unavailable' };
+      }
+      if (callCount === 2) {
+        return {
+          ok: true,
+          text: async () => JSON.stringify({
+            code: 200,
+            data: { id: 'trace-123', state: 'WAITING' },
+          }),
+        };
+      }
+      // 5th call succeeds
+      return {
+        ok: true,
+        text: async () => JSON.stringify({
+          code: 200,
+          data: { id: 'trace-123', state: 'SUCCEED', txnHash: '0xabc' },
+        }),
+      };
+    });
+
+    const result = await client.waitForSuccess('trace-123', 10000, 100, 3);
+    expect(result.state).toBe('SUCCEED');
+    expect(callCount).toBe(5);
+  });
+
   it('should throw on null data from getAddressInfo', async () => {
     (fetch as any).mockResolvedValue({
       ok: true,
@@ -214,6 +247,22 @@ describe('GasFreeAPIClient', () => {
 
     await expect(client.submit({}, message, '0xabc'))
       .rejects.toThrow('null data');
+  });
+
+  it('should throw on submit data without id field', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ code: 200, data: { state: 'WAITING' } }),
+    });
+
+    const message = {
+      token: '0xtoken', serviceProvider: '0xprovider', user: '0xuser',
+      receiver: '0xreceiver', value: 100, maxFee: 10, deadline: 1000,
+      version: 1, nonce: 1,
+    };
+
+    await expect(client.submit({}, message, '0xabc'))
+      .rejects.toThrow('without id field');
   });
 
   it('should get nonce', async () => {

--- a/typescript/packages/x402/src/utils/gasfree.ts
+++ b/typescript/packages/x402/src/utils/gasfree.ts
@@ -35,7 +35,7 @@ export interface GasFreeAddressInfo {
 
 export interface GasFreeSubmitResponseData {
   id: string;
-  state?: 'WAITING' | 'INPROGRESS' | 'CONFIRMING' | 'SUCCEED' | 'FAILED';
+  state: 'WAITING' | 'INPROGRESS' | 'CONFIRMING' | 'SUCCEED' | 'FAILED';
   createdAt: string;
   accountAddress: string;
   gasFreeAddress: string;
@@ -185,7 +185,7 @@ export class GasFreeAPIClient {
       console.error(`GasFree config API business error at ${url}: ${result.message || result.reason}`);
       throw new Error(`GasFree config API error: ${result.message || result.reason}`);
     }
-    if (!result.data) {
+    if (result.data == null) {
       throw new Error('GasFree config API returned null data');
     }
     return result.data.providers;
@@ -224,7 +224,7 @@ export class GasFreeAPIClient {
       console.error(`GasFree API business error at ${url}: ${result.message || result.reason} - Body: ${bodyText}`);
       throw new Error(`GasFree API error: ${result.message || result.reason} - Body: ${bodyText}`);
     }
-    if (!result.data) {
+    if (result.data == null) {
       throw new Error(`GasFree API returned null data for address ${user}`);
     }
     return result.data;
@@ -268,6 +268,7 @@ export class GasFreeAPIClient {
       let statusData: GasFreeSubmitResponseData | null;
       try {
         statusData = await this.getStatus(traceId);
+        errorCount = 0; // reset on successful poll
       } catch (err) {
         errorCount++;
         console.warn(`GasFree status poll failed for ${traceId} (error #${errorCount}): ${err}, retrying...`);
@@ -277,7 +278,7 @@ export class GasFreeAPIClient {
         await new Promise((resolve) => setTimeout(resolve, pollInterval));
         continue;
       }
-      if (!statusData) {
+      if (statusData == null) {
         console.debug(`GasFree transaction ${traceId} status not yet available, waiting...`);
         await new Promise((resolve) => setTimeout(resolve, pollInterval));
         continue;
@@ -342,8 +343,11 @@ export class GasFreeAPIClient {
         console.error(`GasFree submit API business error at ${url}: ${result.message || result.reason} - Body: ${bodyText}`);
         throw new Error(`GasFree submit API error: ${result.message || result.reason} - Body: ${bodyText}`);
       }
-      if (!result.data) {
+      if (result.data == null) {
         throw new Error('GasFree submit API returned null data');
+      }
+      if (result.data.id == null) {
+        throw new Error('GasFree submit API returned data without id field');
       }
       return result.data.id;
     } catch (error) {

--- a/typescript/packages/x402/src/utils/gasfree.ts
+++ b/typescript/packages/x402/src/utils/gasfree.ts
@@ -11,7 +11,7 @@ export interface GasFreeResponse<T> {
   code: number;
   reason: string | null;
   message: string | null;
-  data: T;
+  data: T | null;
 }
 
 export interface GasFreeAsset {
@@ -185,6 +185,9 @@ export class GasFreeAPIClient {
       console.error(`GasFree config API business error at ${url}: ${result.message || result.reason}`);
       throw new Error(`GasFree config API error: ${result.message || result.reason}`);
     }
+    if (!result.data) {
+      throw new Error('GasFree config API returned null data');
+    }
     return result.data.providers;
   }
 
@@ -221,13 +224,16 @@ export class GasFreeAPIClient {
       console.error(`GasFree API business error at ${url}: ${result.message || result.reason} - Body: ${bodyText}`);
       throw new Error(`GasFree API error: ${result.message || result.reason} - Body: ${bodyText}`);
     }
+    if (!result.data) {
+      throw new Error(`GasFree API returned null data for address ${user}`);
+    }
     return result.data;
   }
 
   /**
    * Get status of a submitted GasFree transaction
    */
-  async getStatus(traceId: string): Promise<GasFreeSubmitResponseData> {
+  async getStatus(traceId: string): Promise<GasFreeSubmitResponseData | null> {
     const path = `/api/v1/gasfree/${traceId}`;
     const url = `${this.baseUrl}${path}`;
     const headers = await this.getHeaders('GET', path);
@@ -257,8 +263,20 @@ export class GasFreeAPIClient {
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeout) {
-      const statusData = await this.getStatus(traceId);
-      const state = statusData.state.toUpperCase();
+      let statusData: GasFreeSubmitResponseData | null;
+      try {
+        statusData = await this.getStatus(traceId);
+      } catch (err) {
+        console.warn(`GasFree status poll failed for ${traceId}: ${err}, retrying...`);
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+        continue;
+      }
+      if (!statusData) {
+        console.debug(`GasFree transaction ${traceId} status not yet available, waiting...`);
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+        continue;
+      }
+      const state = (statusData.state || '').toUpperCase();
       const txnState = (statusData.txnState || '').toUpperCase();
 
       // 1. Immediate return for successful or "good enough" states
@@ -317,6 +335,9 @@ export class GasFreeAPIClient {
       if (result.code !== 200) {
         console.error(`GasFree submit API business error at ${url}: ${result.message || result.reason} - Body: ${bodyText}`);
         throw new Error(`GasFree submit API error: ${result.message || result.reason} - Body: ${bodyText}`);
+      }
+      if (!result.data) {
+        throw new Error('GasFree submit API returned null data');
       }
       return result.data.id;
     } catch (error) {

--- a/typescript/packages/x402/src/utils/gasfree.ts
+++ b/typescript/packages/x402/src/utils/gasfree.ts
@@ -35,7 +35,7 @@ export interface GasFreeAddressInfo {
 
 export interface GasFreeSubmitResponseData {
   id: string;
-  state: 'WAITING' | 'INPROGRESS' | 'CONFIRMING' | 'SUCCEED' | 'FAILED';
+  state?: 'WAITING' | 'INPROGRESS' | 'CONFIRMING' | 'SUCCEED' | 'FAILED';
   createdAt: string;
   accountAddress: string;
   gasFreeAddress: string;
@@ -258,7 +258,8 @@ export class GasFreeAPIClient {
   async waitForSuccess(
     traceId: string,
     timeout: number = 120000,
-    pollInterval: number = 5000
+    pollInterval: number = 5000,
+    maxErrors: number = 3
   ): Promise<GasFreeSubmitResponseData> {
     const startTime = Date.now();
     let errorCount = 0;
@@ -270,6 +271,9 @@ export class GasFreeAPIClient {
       } catch (err) {
         errorCount++;
         console.warn(`GasFree status poll failed for ${traceId} (error #${errorCount}): ${err}, retrying...`);
+        if (errorCount >= maxErrors) {
+          throw new Error(`GasFree status polling aborted after ${errorCount} consecutive errors: ${err}`);
+        }
         await new Promise((resolve) => setTimeout(resolve, pollInterval));
         continue;
       }
@@ -278,7 +282,7 @@ export class GasFreeAPIClient {
         await new Promise((resolve) => setTimeout(resolve, pollInterval));
         continue;
       }
-      const state = (statusData.state || '').toUpperCase();
+      const state = (statusData.state ?? '').toUpperCase();
       const txnState = (statusData.txnState || '').toUpperCase();
 
       // 1. Immediate return for successful or "good enough" states

--- a/typescript/packages/x402/src/utils/gasfree.ts
+++ b/typescript/packages/x402/src/utils/gasfree.ts
@@ -261,13 +261,15 @@ export class GasFreeAPIClient {
     pollInterval: number = 5000
   ): Promise<GasFreeSubmitResponseData> {
     const startTime = Date.now();
+    let errorCount = 0;
 
     while (Date.now() - startTime < timeout) {
       let statusData: GasFreeSubmitResponseData | null;
       try {
         statusData = await this.getStatus(traceId);
       } catch (err) {
-        console.warn(`GasFree status poll failed for ${traceId}: ${err}, retrying...`);
+        errorCount++;
+        console.warn(`GasFree status poll failed for ${traceId} (error #${errorCount}): ${err}, retrying...`);
         await new Promise((resolve) => setTimeout(resolve, pollInterval));
         continue;
       }
@@ -292,7 +294,7 @@ export class GasFreeAPIClient {
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
 
-    throw new Error(`GasFree transaction ${traceId} timed out after ${timeout / 1000}s`);
+    throw new Error(`GasFree transaction ${traceId} timed out after ${timeout / 1000}s (${errorCount} errors encountered)`);
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Root cause**: GasFree status API returns `{"code": 200, "data": null}` when polled immediately after submission. `wait_for_success` accessed `.get("state")` on `None`, causing `AttributeError` in the facilitator — even though the gasfree transaction succeeded on-chain.
- Guard all `result.data` access across both Python and TypeScript:
  - `waitForSuccess`/`wait_for_success`: skip null status data and retry on transient HTTP errors
  - `getStatus`/`get_status`: return `null`/`None` honestly instead of defaulting to `{}`
  - `getAddressInfo`, `getProviders`, `submit`: throw explicitly on null data
- Type `GasFreeResponse<T>.data` as `T | null` to reflect API reality

## Test plan
- [x] New TS test: `should handle null status data in waitForSuccess` — passes
- [x] New Python test: `test_wait_for_success_handles_null_status_data`
- [x] Full TS test suite passes (26/26)
- [ ] Python test suite (no pytest available in CI-less env, needs CI run)
- [ ] Manual test against mainnet gasfree endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)