### PR TITLE
feat: fallback RPC for TRON mainnet without API key

### DIFF
--- a/python/x402/src/bankofai/x402/utils/tron_client.py
+++ b/python/x402/src/bankofai/x402/utils/tron_client.py
@@ -32,11 +32,19 @@ def create_async_tron_client(network: str) -> Any:
 
     api_key = os.getenv("TRON_GRID_API_KEY")
     if not api_key:
+        if network == "mainnet":
+            fallback_url = "https://hptg.bankofai.io"
+            logger.info(
+                "TRON_GRID_API_KEY is not set. Using fallback RPC for mainnet: %s",
+                fallback_url,
+            )
+            provider = AsyncHTTPProvider(endpoint_uri=fallback_url)
+            return AsyncTron(provider=provider, network=network)
+
         logger.warning(
-            "TRON_GRID_API_KEY is not set. Mainnet requests may be rate-limited or fail; "
+            "TRON_GRID_API_KEY is not set. Requests may be rate-limited or fail; "
             "set TRON_GRID_API_KEY in your environment/.env to use TronGrid reliably."
         )
-
         logger.info("Creating AsyncTron client for network=%s", network)
         return AsyncTron(network=network)
 

--- a/python/x402/src/bankofai/x402/utils/tron_client.py
+++ b/python/x402/src/bankofai/x402/utils/tron_client.py
@@ -14,11 +14,16 @@ from tronpy.providers.async_http import AsyncHTTPProvider
 
 logger = logging.getLogger(__name__)
 
+TRON_MAINNET_FALLBACK_URL = "https://hptg.bankofai.io"
+
 
 def create_async_tron_client(network: str) -> Any:
     """Create an AsyncTron client for the given network.
 
-    Automatically uses TronGrid API key from TRON_GRID_API_KEY env var if set.
+    When TRON_GRID_API_KEY env var is set, uses TronGrid with the API key.
+    When not set and network is mainnet, uses the BankOfAI fallback RPC
+    (https://hptg.bankofai.io). For other networks without an API key,
+    tronpy defaults are used.
 
     Args:
         network: TRON network name (e.g. "nile", "mainnet") or full identifier (e.g. "tron:nile")
@@ -33,12 +38,12 @@ def create_async_tron_client(network: str) -> Any:
     api_key = os.getenv("TRON_GRID_API_KEY")
     if not api_key:
         if network == "mainnet":
-            fallback_url = "https://hptg.bankofai.io"
-            logger.info(
-                "TRON_GRID_API_KEY is not set. Using fallback RPC for mainnet: %s",
-                fallback_url,
+            logger.warning(
+                "TRON_GRID_API_KEY is not set. Mainnet RPC calls will be routed to %s. "
+                "Set TRON_GRID_API_KEY to use TronGrid.",
+                TRON_MAINNET_FALLBACK_URL,
             )
-            provider = AsyncHTTPProvider(endpoint_uri=fallback_url)
+            provider = AsyncHTTPProvider(endpoint_uri=TRON_MAINNET_FALLBACK_URL)
             return AsyncTron(provider=provider, network=network)
 
         logger.warning(

--- a/python/x402/src/bankofai/x402/utils/tron_client.py
+++ b/python/x402/src/bankofai/x402/utils/tron_client.py
@@ -44,6 +44,11 @@ def create_async_tron_client(network: str) -> Any:
                 TRON_MAINNET_FALLBACK_URL,
             )
             provider = AsyncHTTPProvider(endpoint_uri=TRON_MAINNET_FALLBACK_URL)
+            logger.info(
+                "Creating AsyncTron client with fallback provider for network=%s (%s)",
+                network,
+                TRON_MAINNET_FALLBACK_URL,
+            )
             return AsyncTron(provider=provider, network=network)
 
         logger.warning(

--- a/python/x402/tests/utils/test_tron_client_factory.py
+++ b/python/x402/tests/utils/test_tron_client_factory.py
@@ -7,9 +7,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from tronpy.providers.async_http import AsyncHTTPProvider
 
-from bankofai.x402.utils.tron_client import create_async_tron_client
-
-FALLBACK_URL = "https://hptg.bankofai.io"
+from bankofai.x402.utils.tron_client import (
+    TRON_MAINNET_FALLBACK_URL,
+    create_async_tron_client,
+)
 
 
 class TestCreateAsyncTronClientFallback:
@@ -25,7 +26,7 @@ class TestCreateAsyncTronClientFallback:
 
         create_async_tron_client("mainnet")
 
-        mock_provider_cls.assert_called_once_with(endpoint_uri="https://hptg.bankofai.io")
+        mock_provider_cls.assert_called_once_with(endpoint_uri=TRON_MAINNET_FALLBACK_URL)
         mock_tron_cls.assert_called_once_with(provider=mock_provider, network="mainnet")
 
     @patch("bankofai.x402.utils.tron_client.AsyncTron")
@@ -38,7 +39,7 @@ class TestCreateAsyncTronClientFallback:
 
         create_async_tron_client("tron:mainnet")
 
-        mock_provider_cls.assert_called_once_with(endpoint_uri="https://hptg.bankofai.io")
+        mock_provider_cls.assert_called_once_with(endpoint_uri=TRON_MAINNET_FALLBACK_URL)
         mock_tron_cls.assert_called_once_with(provider=mock_provider, network="mainnet")
 
     @patch("bankofai.x402.utils.tron_client.AsyncTron")
@@ -75,14 +76,14 @@ class TestFallbackClientFunctional:
         """Without API key, mainnet client provider must point to the fallback URL."""
         client = create_async_tron_client("tron:mainnet")
         assert isinstance(client.provider, AsyncHTTPProvider)
-        assert client.provider.endpoint_uri == FALLBACK_URL
+        assert client.provider.endpoint_uri == TRON_MAINNET_FALLBACK_URL
 
     @pytest.mark.anyio
     @patch.dict("os.environ", {}, clear=True)
     async def test_fallback_client_can_fetch_block(self):
         """The fallback client should be able to fetch the latest block."""
         client = create_async_tron_client("tron:mainnet")
-        assert client.provider.endpoint_uri == FALLBACK_URL
+        assert client.provider.endpoint_uri == TRON_MAINNET_FALLBACK_URL
         async with client:
             block = await client.get_latest_block()
             assert block is not None

--- a/python/x402/tests/utils/test_tron_client_factory.py
+++ b/python/x402/tests/utils/test_tron_client_factory.py
@@ -1,0 +1,89 @@
+"""
+Tests for create_async_tron_client fallback RPC URL behavior.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from tronpy.providers.async_http import AsyncHTTPProvider
+
+from bankofai.x402.utils.tron_client import create_async_tron_client
+
+FALLBACK_URL = "https://hptg.bankofai.io"
+
+
+class TestCreateAsyncTronClientFallback:
+    """Tests for RPC URL selection based on TRON_GRID_API_KEY."""
+
+    @patch("bankofai.x402.utils.tron_client.AsyncTron")
+    @patch("bankofai.x402.utils.tron_client.AsyncHTTPProvider")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_mainnet_uses_fallback_url_without_api_key(self, mock_provider_cls, mock_tron_cls):
+        """When TRON_GRID_API_KEY is not set, mainnet should use the fallback RPC URL."""
+        mock_provider = MagicMock()
+        mock_provider_cls.return_value = mock_provider
+
+        create_async_tron_client("mainnet")
+
+        mock_provider_cls.assert_called_once_with(endpoint_uri="https://hptg.bankofai.io")
+        mock_tron_cls.assert_called_once_with(provider=mock_provider, network="mainnet")
+
+    @patch("bankofai.x402.utils.tron_client.AsyncTron")
+    @patch("bankofai.x402.utils.tron_client.AsyncHTTPProvider")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_mainnet_with_tron_prefix_uses_fallback(self, mock_provider_cls, mock_tron_cls):
+        """tron:mainnet prefix should be stripped and fallback URL used."""
+        mock_provider = MagicMock()
+        mock_provider_cls.return_value = mock_provider
+
+        create_async_tron_client("tron:mainnet")
+
+        mock_provider_cls.assert_called_once_with(endpoint_uri="https://hptg.bankofai.io")
+        mock_tron_cls.assert_called_once_with(provider=mock_provider, network="mainnet")
+
+    @patch("bankofai.x402.utils.tron_client.AsyncTron")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_nile_uses_default_without_api_key(self, mock_tron_cls):
+        """Non-mainnet networks should use tronpy defaults when API key is not set."""
+        create_async_tron_client("nile")
+
+        mock_tron_cls.assert_called_once_with(network="nile")
+
+    @patch("bankofai.x402.utils.tron_client.AsyncTron")
+    @patch("bankofai.x402.utils.tron_client.AsyncHTTPProvider")
+    @patch("bankofai.x402.utils.tron_client.conf_for_name")
+    @patch.dict("os.environ", {"TRON_GRID_API_KEY": "test-key"})
+    def test_mainnet_uses_trongrid_with_api_key(self, mock_conf, mock_provider_cls, mock_tron_cls):
+        """When TRON_GRID_API_KEY is set, mainnet should use the TronGrid URL."""
+        mock_conf.return_value = {"fullnode": "https://api.trongrid.io"}
+        mock_provider = MagicMock()
+        mock_provider_cls.return_value = mock_provider
+
+        create_async_tron_client("mainnet")
+
+        mock_provider_cls.assert_called_once_with(
+            endpoint_uri="https://api.trongrid.io", api_key="test-key"
+        )
+        mock_tron_cls.assert_called_once_with(provider=mock_provider, network="mainnet")
+
+
+class TestFallbackClientFunctional:
+    """Verify the fallback client actually connects to the correct endpoint."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_fallback_client_has_correct_rpc_url(self):
+        """Without API key, mainnet client provider must point to the fallback URL."""
+        client = create_async_tron_client("tron:mainnet")
+        assert isinstance(client.provider, AsyncHTTPProvider)
+        assert client.provider.endpoint_uri == FALLBACK_URL
+
+    @pytest.mark.anyio
+    @patch.dict("os.environ", {}, clear=True)
+    async def test_fallback_client_can_fetch_block(self):
+        """The fallback client should be able to fetch the latest block."""
+        client = create_async_tron_client("tron:mainnet")
+        assert client.provider.endpoint_uri == FALLBACK_URL
+        async with client:
+            block = await client.get_latest_block()
+            assert block is not None
+            assert block["block_header"]["raw_data"]["number"] > 0

--- a/typescript/packages/x402/src/config.test.ts
+++ b/typescript/packages/x402/src/config.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getTronRpcUrl, TRON_RPC_URLS, TRON_FALLBACK_RPC_URLS } from './config.js';
+import { getTronRpcUrl, TRON_RPC_URLS, TRON_FALLBACK_RPC_URLS, resolveRpcUrl } from './config.js';
+
+const FALLBACK_URL = TRON_FALLBACK_RPC_URLS['tron:mainnet'];
 
 describe('getTronRpcUrl', () => {
   const originalEnv = process.env;
@@ -14,7 +16,7 @@ describe('getTronRpcUrl', () => {
   });
 
   it('returns fallback URL for mainnet when TRON_GRID_API_KEY is not set', () => {
-    expect(getTronRpcUrl('tron:mainnet')).toBe('https://hptg.bankofai.io');
+    expect(getTronRpcUrl('tron:mainnet')).toBe(FALLBACK_URL);
   });
 
   it('returns default TronGrid URL for mainnet when TRON_GRID_API_KEY is set', () => {
@@ -40,5 +42,27 @@ describe('getTronRpcUrl', () => {
   it('returns undefined for unknown networks when TRON_GRID_API_KEY is set', () => {
     process.env.TRON_GRID_API_KEY = 'test-api-key';
     expect(getTronRpcUrl('tron:unknown')).toBeUndefined();
+  });
+});
+
+describe('resolveRpcUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.TRON_GRID_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('delegates to getTronRpcUrl for TRON networks', () => {
+    expect(resolveRpcUrl('tron:mainnet')).toBe(FALLBACK_URL);
+  });
+
+  it('returns TronGrid URL for TRON mainnet when API key is set', () => {
+    process.env.TRON_GRID_API_KEY = 'test-api-key';
+    expect(resolveRpcUrl('tron:mainnet')).toBe('https://api.trongrid.io');
   });
 });

--- a/typescript/packages/x402/src/config.test.ts
+++ b/typescript/packages/x402/src/config.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getTronRpcUrl, TRON_RPC_URLS, TRON_FALLBACK_RPC_URLS } from './config.js';
+
+describe('getTronRpcUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.TRON_GRID_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns fallback URL for mainnet when TRON_GRID_API_KEY is not set', () => {
+    expect(getTronRpcUrl('tron:mainnet')).toBe('https://hptg.bankofai.io');
+  });
+
+  it('returns default TronGrid URL for mainnet when TRON_GRID_API_KEY is set', () => {
+    process.env.TRON_GRID_API_KEY = 'test-api-key';
+    expect(getTronRpcUrl('tron:mainnet')).toBe('https://api.trongrid.io');
+  });
+
+  it('returns default URL for non-mainnet networks when TRON_GRID_API_KEY is not set', () => {
+    expect(getTronRpcUrl('tron:nile')).toBe(TRON_RPC_URLS['tron:nile']);
+    expect(getTronRpcUrl('tron:shasta')).toBe(TRON_RPC_URLS['tron:shasta']);
+  });
+
+  it('returns default URL for non-mainnet networks when TRON_GRID_API_KEY is set', () => {
+    process.env.TRON_GRID_API_KEY = 'test-api-key';
+    expect(getTronRpcUrl('tron:nile')).toBe(TRON_RPC_URLS['tron:nile']);
+    expect(getTronRpcUrl('tron:shasta')).toBe(TRON_RPC_URLS['tron:shasta']);
+  });
+
+  it('returns undefined for unknown networks', () => {
+    expect(getTronRpcUrl('tron:unknown')).toBeUndefined();
+  });
+
+  it('returns undefined for unknown networks when TRON_GRID_API_KEY is set', () => {
+    process.env.TRON_GRID_API_KEY = 'test-api-key';
+    expect(getTronRpcUrl('tron:unknown')).toBeUndefined();
+  });
+});

--- a/typescript/packages/x402/src/config.ts
+++ b/typescript/packages/x402/src/config.ts
@@ -87,7 +87,15 @@ export const TRON_FALLBACK_RPC_URLS: Record<string, string> = {
 export function getTronRpcUrl(network: string): string | undefined {
   const apiKey = typeof process !== 'undefined' ? process.env?.TRON_GRID_API_KEY : undefined;
   if (!apiKey) {
-    return TRON_FALLBACK_RPC_URLS[network] ?? TRON_RPC_URLS[network];
+    const fallback = TRON_FALLBACK_RPC_URLS[network];
+    if (fallback) {
+      console.warn(
+        `[x402] TRON_GRID_API_KEY is not set. Routing ${network} RPC calls ` +
+        `to fallback endpoint: ${fallback}. Set TRON_GRID_API_KEY to use TronGrid.`
+      );
+      return fallback;
+    }
+    return TRON_RPC_URLS[network];
   }
   return TRON_RPC_URLS[network];
 }
@@ -97,7 +105,10 @@ export function getTronRpcUrl(network: string): string | undefined {
  * Returns the URL from the built-in map, or undefined if not configured.
  */
 export function resolveRpcUrl(network: string): string | undefined {
-  return EVM_RPC_URLS[network] ?? TRON_RPC_URLS[network];
+  if (network.startsWith('tron:')) {
+    return getTronRpcUrl(network);
+  }
+  return EVM_RPC_URLS[network];
 }
 
 /** Zero address for TRON */

--- a/typescript/packages/x402/src/config.ts
+++ b/typescript/packages/x402/src/config.ts
@@ -84,15 +84,20 @@ export const TRON_FALLBACK_RPC_URLS: Record<string, string> = {
  * Get the appropriate TRON RPC URL for a network.
  * Uses fallback URLs when TRON_GRID_API_KEY is not set.
  */
+const _warnedNetworks = new Set<string>();
+
 export function getTronRpcUrl(network: string): string | undefined {
   const apiKey = typeof process !== 'undefined' ? process.env?.TRON_GRID_API_KEY : undefined;
   if (!apiKey) {
     const fallback = TRON_FALLBACK_RPC_URLS[network];
     if (fallback) {
-      console.warn(
-        `[x402] TRON_GRID_API_KEY is not set. Routing ${network} RPC calls ` +
-        `to fallback endpoint: ${fallback}. Set TRON_GRID_API_KEY to use TronGrid.`
-      );
+      if (!_warnedNetworks.has(network)) {
+        _warnedNetworks.add(network);
+        console.warn(
+          `[x402] TRON_GRID_API_KEY is not set. Routing ${network} RPC calls ` +
+          `to fallback endpoint: ${fallback}. Set TRON_GRID_API_KEY to use TronGrid.`
+        );
+      }
       return fallback;
     }
     return TRON_RPC_URLS[network];

--- a/typescript/packages/x402/src/config.ts
+++ b/typescript/packages/x402/src/config.ts
@@ -75,6 +75,23 @@ export const TRON_RPC_URLS: Record<string, string> = {
   'tron:nile': 'https://nile.trongrid.io',
 };
 
+/** Fallback RPC URLs used when TRON_GRID_API_KEY is not set */
+export const TRON_FALLBACK_RPC_URLS: Record<string, string> = {
+  'tron:mainnet': 'https://hptg.bankofai.io',
+};
+
+/**
+ * Get the appropriate TRON RPC URL for a network.
+ * Uses fallback URLs when TRON_GRID_API_KEY is not set.
+ */
+export function getTronRpcUrl(network: string): string | undefined {
+  const apiKey = typeof process !== 'undefined' ? process.env?.TRON_GRID_API_KEY : undefined;
+  if (!apiKey) {
+    return TRON_FALLBACK_RPC_URLS[network] ?? TRON_RPC_URLS[network];
+  }
+  return TRON_RPC_URLS[network];
+}
+
 /**
  * Resolve a network identifier to an RPC URL.
  * Returns the URL from the built-in map, or undefined if not configured.

--- a/typescript/packages/x402/src/signers/signer.ts
+++ b/typescript/packages/x402/src/signers/signer.ts
@@ -12,7 +12,7 @@ import {
   SignatureCreationError,
   InsufficientAllowanceError,
   UnsupportedNetworkError,
-  TRON_RPC_URLS,
+  getTronRpcUrl,
 } from '../index.js';
 import { resolveWalletProvider } from '@bankofai/agent-wallet';
 import { TronWeb as TronWebClass } from 'tronweb';
@@ -87,7 +87,7 @@ export class TronClientSigner implements ClientSigner {
    * Get or create a TronWeb instance for the given network.
    */
   private getTronWeb(network?: string): TronWeb {
-    const host = network ? TRON_RPC_URLS[network] : undefined;
+    const host = network ? getTronRpcUrl(network) : undefined;
     const key = host ?? '__default__';
     let tw = this.tronWebInstances.get(key);
     if (!tw) {

--- a/typescript/packages/x402/src/signers/tronSigner.test.ts
+++ b/typescript/packages/x402/src/signers/tronSigner.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TronClientSigner } from './signer.js';
 import type { AgentWallet } from './signer.js';
 import * as config from '../config.js';
+import { TRON_FALLBACK_RPC_URLS } from '../config.js';
 
 vi.mock('@bankofai/agent-wallet', () => ({
   resolveWalletProvider: vi.fn(),
@@ -9,7 +10,9 @@ vi.mock('@bankofai/agent-wallet', () => ({
 
 // USDT on TRON mainnet
 const MAINNET_USDT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
-const FALLBACK_URL = 'https://hptg.bankofai.io';
+// A real EOA wallet address on mainnet
+const TEST_WALLET = 'TDqjTkZ3ExHxRzaLSrdnzSBGhfbPXnBQoN';
+const FALLBACK_URL = TRON_FALLBACK_RPC_URLS['tron:mainnet'];
 
 function createMockWallet(address: string): AgentWallet {
   return {
@@ -35,9 +38,9 @@ describe('TronClientSigner fallback RPC', () => {
   it('uses fallback RPC URL and checkBalance succeeds on tron:mainnet without TRON_GRID_API_KEY', async () => {
     const spy = vi.spyOn(config, 'getTronRpcUrl');
 
-    const wallet = createMockWallet(MAINNET_USDT);
+    const wallet = createMockWallet(TEST_WALLET);
     const signer = new TronClientSigner(wallet);
-    signer.setAddress(MAINNET_USDT);
+    signer.setAddress(TEST_WALLET);
 
     const balance = await signer.checkBalance(MAINNET_USDT, 'tron:mainnet');
 
@@ -45,9 +48,9 @@ describe('TronClientSigner fallback RPC', () => {
     expect(spy).toHaveBeenCalledWith('tron:mainnet');
     expect(spy).toHaveReturnedWith(FALLBACK_URL);
 
-    // Verify the RPC call actually succeeded
+    // Verify the RPC call actually succeeded and returned a valid bigint
     expect(typeof balance).toBe('bigint');
-    expect(balance).toBeGreaterThan(BigInt(0));
+    expect(balance).toBeGreaterThanOrEqual(BigInt(0));
 
     spy.mockRestore();
   });

--- a/typescript/packages/x402/src/signers/tronSigner.test.ts
+++ b/typescript/packages/x402/src/signers/tronSigner.test.ts
@@ -10,8 +10,6 @@ vi.mock('@bankofai/agent-wallet', () => ({
 
 // USDT on TRON mainnet
 const MAINNET_USDT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
-// A real EOA wallet address on mainnet
-const TEST_WALLET = 'TDqjTkZ3ExHxRzaLSrdnzSBGhfbPXnBQoN';
 const FALLBACK_URL = TRON_FALLBACK_RPC_URLS['tron:mainnet'];
 
 function createMockWallet(address: string): AgentWallet {
@@ -36,22 +34,27 @@ describe('TronClientSigner fallback RPC', () => {
   });
 
   it('uses fallback RPC URL and checkBalance succeeds on tron:mainnet without TRON_GRID_API_KEY', async () => {
-    const spy = vi.spyOn(config, 'getTronRpcUrl');
+    const rpcSpy = vi.spyOn(config, 'getTronRpcUrl');
+    const errorSpy = vi.spyOn(console, 'error');
 
-    const wallet = createMockWallet(TEST_WALLET);
+    const wallet = createMockWallet(MAINNET_USDT);
     const signer = new TronClientSigner(wallet);
-    signer.setAddress(TEST_WALLET);
+    signer.setAddress(MAINNET_USDT);
 
     const balance = await signer.checkBalance(MAINNET_USDT, 'tron:mainnet');
 
     // Verify getTronRpcUrl was called with mainnet and returned the fallback URL
-    expect(spy).toHaveBeenCalledWith('tron:mainnet');
-    expect(spy).toHaveReturnedWith(FALLBACK_URL);
+    expect(rpcSpy).toHaveBeenCalledWith('tron:mainnet');
+    expect(rpcSpy).toHaveReturnedWith(FALLBACK_URL);
+
+    // Verify no error was logged (i.e. the RPC call didn't silently fail)
+    expect(errorSpy).not.toHaveBeenCalled();
 
     // Verify the RPC call actually succeeded and returned a valid bigint
     expect(typeof balance).toBe('bigint');
     expect(balance).toBeGreaterThanOrEqual(BigInt(0));
 
-    spy.mockRestore();
+    rpcSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/typescript/packages/x402/src/signers/tronSigner.test.ts
+++ b/typescript/packages/x402/src/signers/tronSigner.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TronClientSigner } from './signer.js';
+import type { AgentWallet } from './signer.js';
+import * as config from '../config.js';
+
+vi.mock('@bankofai/agent-wallet', () => ({
+  resolveWalletProvider: vi.fn(),
+}));
+
+// USDT on TRON mainnet
+const MAINNET_USDT = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+const FALLBACK_URL = 'https://hptg.bankofai.io';
+
+function createMockWallet(address: string): AgentWallet {
+  return {
+    getAddress: vi.fn().mockResolvedValue(address),
+    signMessage: vi.fn().mockResolvedValue('0xdeadbeef'),
+    signTypedData: vi.fn().mockResolvedValue('0x' + 'ab'.repeat(65)),
+    signTransaction: vi.fn().mockResolvedValue('0x1234'),
+  };
+}
+
+describe('TronClientSigner fallback RPC', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.TRON_GRID_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses fallback RPC URL and checkBalance succeeds on tron:mainnet without TRON_GRID_API_KEY', async () => {
+    const spy = vi.spyOn(config, 'getTronRpcUrl');
+
+    const wallet = createMockWallet(MAINNET_USDT);
+    const signer = new TronClientSigner(wallet);
+    signer.setAddress(MAINNET_USDT);
+
+    const balance = await signer.checkBalance(MAINNET_USDT, 'tron:mainnet');
+
+    // Verify getTronRpcUrl was called with mainnet and returned the fallback URL
+    expect(spy).toHaveBeenCalledWith('tron:mainnet');
+    expect(spy).toHaveReturnedWith(FALLBACK_URL);
+
+    // Verify the RPC call actually succeeded
+    expect(typeof balance).toBe('bigint');
+    expect(balance).toBeGreaterThan(BigInt(0));
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- When `TRON_GRID_API_KEY` is not set, the TRON signer now uses `https://hptg.bankofai.io` as the mainnet RPC instead of the rate-limited TronGrid endpoint
- When `TRON_GRID_API_KEY` is set, behavior is unchanged (uses TronGrid with the API key)
- Applies to both TypeScript and Python SDKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)