### PR TITLE
fix: improve GasFree API client reliability

### DIFF
--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -41,6 +41,7 @@ class GasFreeAPIClient:
         from bankofai.x402.config import NetworkConfig
 
         self.base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(timeout=30.0)
 
         # If keys are missing, try to infer the network from base_url to fetch env-specific keys
         if not api_key or not api_secret:
@@ -95,51 +96,49 @@ class GasFreeAPIClient:
     async def get_address_info(self, user: str) -> Dict[str, Any]:
         """Get full account info (activation, balance, nonce) for a user"""
         path = f"/api/v1/address/{user}"
-        async with httpx.AsyncClient() as client:
-            url = f"{self.base_url}{path}"
-            try:
-                headers = self._get_headers("GET", path)
-                response = await client.get(url, headers=headers)
-                if response.status_code != 200:
-                    logger.error(f"GasFree API error {response.status_code}: {response.text}")
-                    response.raise_for_status()
-                result = response.json()
-                if result.get("code") != 200:
-                    err_msg = result.get("message") or result.get("reason")
-                    raise RuntimeError(f"API business error: {err_msg} - Body: {response.text}")
-                data = result.get("data")
-                if data is None:
-                    raise RuntimeError(f"GasFree API returned null data for address {user}")
-                return data
-            except Exception as e:
-                if isinstance(e, httpx.HTTPStatusError):
-                    logger.error(f"HTTP Status Error Body: {e.response.text}")
-                logger.error(f"Failed to get address info from GasFree API from {url}: {e}")
-                raise
+        url = f"{self.base_url}{path}"
+        try:
+            headers = self._get_headers("GET", path)
+            response = await self._client.get(url, headers=headers)
+            if response.status_code != 200:
+                logger.error(f"GasFree API error {response.status_code}: {response.text}")
+                response.raise_for_status()
+            result = response.json()
+            if result.get("code") != 200:
+                err_msg = result.get("message") or result.get("reason")
+                raise RuntimeError(f"API business error: {err_msg} - Body: {response.text}")
+            data = result.get("data")
+            if data is None:
+                raise RuntimeError(f"GasFree API returned null data for address {user}")
+            return data
+        except Exception as e:
+            if isinstance(e, httpx.HTTPStatusError):
+                logger.error(f"HTTP Status Error Body: {e.response.text}")
+            logger.error(f"Failed to get address info from GasFree API from {url}: {e}")
+            raise
 
     async def get_providers(self) -> List[Dict[str, Any]]:
         """Get all supported service providers from configuration"""
         path = "/api/v1/config/provider/all"
-        async with httpx.AsyncClient() as client:
-            url = f"{self.base_url}{path}"
-            try:
-                headers = self._get_headers("GET", path)
-                response = await client.get(url, headers=headers)
-                if response.status_code != 200:
-                    logger.error(f"GasFree API error {response.status_code}: {response.text}")
-                    response.raise_for_status()
-                result = response.json()
-                if result.get("code") != 200:
-                    raise RuntimeError(
-                        f"API business error: {result.get('message') or result.get('reason')}"
-                    )
-                data = result.get("data")
-                if data is None:
-                    raise RuntimeError("GasFree config API returned null data")
-                return data.get("providers", [])
-            except Exception as e:
-                logger.error(f"Failed to get providers from GasFree API: {e}")
-                raise
+        url = f"{self.base_url}{path}"
+        try:
+            headers = self._get_headers("GET", path)
+            response = await self._client.get(url, headers=headers)
+            if response.status_code != 200:
+                logger.error(f"GasFree API error {response.status_code}: {response.text}")
+                response.raise_for_status()
+            result = response.json()
+            if result.get("code") != 200:
+                raise RuntimeError(
+                    f"API business error: {result.get('message') or result.get('reason')}"
+                )
+            data = result.get("data")
+            if data is None:
+                raise RuntimeError("GasFree config API returned null data")
+            return data.get("providers", [])
+        except Exception as e:
+            logger.error(f"Failed to get providers from GasFree API: {e}")
+            raise
 
     async def get_nonce(self, user: str, token: str, chain_id: int) -> int:
         """Get current recommended nonce for a user"""
@@ -156,26 +155,25 @@ class GasFreeAPIClient:
         Returns None if the API returned null data (e.g. status not yet available).
         """
         path = f"/api/v1/gasfree/{trace_id}"
-        async with httpx.AsyncClient() as client:
-            url = f"{self.base_url}{path}"
-            try:
-                headers = self._get_headers("GET", path)
-                response = await client.get(url, headers=headers)
-                if response.status_code != 200:
-                    logger.error(f"GasFree API error {response.status_code}: {response.text}")
-                    response.raise_for_status()
-                result = response.json()
-                if result.get("code") != 200:
-                    raise RuntimeError(
-                        f"API business error: {result.get('message') or result.get('reason')}"
-                    )
-                data = result.get("data")
-                if data is not None:
-                    logger.info(f"GasFree Status Response for {trace_id}: {json.dumps(data)}")
-                return data
-            except Exception as e:
-                logger.error(f"Failed to get GasFree transaction status: {e}")
-                raise
+        url = f"{self.base_url}{path}"
+        try:
+            headers = self._get_headers("GET", path)
+            response = await self._client.get(url, headers=headers)
+            if response.status_code != 200:
+                logger.error(f"GasFree API error {response.status_code}: {response.text}")
+                response.raise_for_status()
+            result = response.json()
+            if result.get("code") != 200:
+                raise RuntimeError(
+                    f"API business error: {result.get('message') or result.get('reason')}"
+                )
+            data = result.get("data")
+            if data is not None:
+                logger.info(f"GasFree Status Response for {trace_id}: {json.dumps(data)}")
+            return data
+        except Exception as e:
+            logger.error(f"Failed to get GasFree transaction status: {e}")
+            raise
 
     async def wait_for_success(
         self,
@@ -235,45 +233,44 @@ class GasFreeAPIClient:
     async def submit(self, domain: Dict[str, Any], message: Dict[str, Any], signature: str) -> str:
         """Submit a signed GasFree transaction to the official relayer"""
         path = "/api/v1/gasfree/submit"
-        async with httpx.AsyncClient() as client:
-            url = f"{self.base_url}{path}"
-            sig = signature[2:] if signature.startswith("0x") else signature
-            payload = {
-                "token": message["token"],
-                "serviceProvider": message["serviceProvider"],
-                "user": message["user"],
-                "receiver": message["receiver"],
-                "value": str(message["value"]),
-                "maxFee": str(message["maxFee"]),
-                "deadline": int(message["deadline"]),
-                "version": 1,
-                "nonce": int(message["nonce"]),
-                "sig": sig,
-                "requestId": f"x402-{int(time.time())}-{sig[:8]}",
-            }
+        url = f"{self.base_url}{path}"
+        sig = signature[2:] if signature.startswith("0x") else signature
+        payload = {
+            "token": message["token"],
+            "serviceProvider": message["serviceProvider"],
+            "user": message["user"],
+            "receiver": message["receiver"],
+            "value": str(message["value"]),
+            "maxFee": str(message["maxFee"]),
+            "deadline": int(message["deadline"]),
+            "version": 1,
+            "nonce": int(message["nonce"]),
+            "sig": sig,
+            "requestId": f"x402-{int(time.time())}-{sig[:8]}",
+        }
 
-            try:
-                headers = self._get_headers("POST", path)
-                response = await client.post(url, json=payload, headers=headers)
-                if response.status_code != 200:
-                    logger.error(f"GasFree API error {response.status_code}: {response.text}")
-                    response.raise_for_status()
-                result = response.json()
-                if result.get("code") != 200:
-                    err_msg = result.get("message") or result.get("reason")
-                    raise RuntimeError(f"API business error: {err_msg} - Body: {response.text}")
-                data = result.get("data")
-                if data is None:
-                    raise RuntimeError("GasFree submit API returned null data")
-                trace_id = data.get("id")
-                if not trace_id:
-                    raise RuntimeError("GasFree submit API returned data without 'id' field")
-                return trace_id
-            except Exception as e:
-                if isinstance(e, httpx.HTTPStatusError):
-                    logger.error(f"HTTP Status Error Body: {e.response.text}")
-                logger.error(f"Failed to submit GasFree transaction to {url}: {e}", exc_info=True)
-                raise
+        try:
+            headers = self._get_headers("POST", path)
+            response = await self._client.post(url, json=payload, headers=headers)
+            if response.status_code != 200:
+                logger.error(f"GasFree API error {response.status_code}: {response.text}")
+                response.raise_for_status()
+            result = response.json()
+            if result.get("code") != 200:
+                err_msg = result.get("message") or result.get("reason")
+                raise RuntimeError(f"API business error: {err_msg} - Body: {response.text}")
+            data = result.get("data")
+            if data is None:
+                raise RuntimeError("GasFree submit API returned null data")
+            trace_id = data.get("id")
+            if not trace_id:
+                raise RuntimeError("GasFree submit API returned data without 'id' field")
+            return trace_id
+        except Exception as e:
+            if isinstance(e, httpx.HTTPStatusError):
+                logger.error(f"HTTP Status Error Body: {e.response.text}")
+            logger.error(f"Failed to submit GasFree transaction to {url}: {e}", exc_info=True)
+            raise
 
 
 def get_gasfree_domain(chain_id: int, verifying_contract: str) -> Dict[str, Any]:

--- a/typescript/packages/x402/src/utils/gasfree.ts
+++ b/typescript/packages/x402/src/utils/gasfree.ts
@@ -78,6 +78,8 @@ export const GASFREE_TYPES = {
   ],
 } as const;
 
+const DEFAULT_TIMEOUT_MS = 30000;
+
 export class GasFreeAPIClient {
   private baseUrl: string;
   private apiKey?: string;
@@ -173,7 +175,7 @@ export class GasFreeAPIClient {
     const url = `${this.baseUrl}${path}`;
     const headers = await this.getHeaders('GET', path);
     
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS) });
     const bodyText = await response.text();
 
     if (!response.ok) {
@@ -212,7 +214,7 @@ export class GasFreeAPIClient {
     const url = `${this.baseUrl}${path}`;
     const headers = await this.getHeaders('GET', path);
 
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS) });
     const bodyText = await response.text();
 
     if (!response.ok) {
@@ -237,7 +239,7 @@ export class GasFreeAPIClient {
     const path = `/api/v1/gasfree/${traceId}`;
     const url = `${this.baseUrl}${path}`;
     const headers = await this.getHeaders('GET', path);
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS) });
     const bodyText = await response.text();
 
     if (!response.ok) {
@@ -329,6 +331,7 @@ export class GasFreeAPIClient {
         method: 'POST',
         headers,
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
       });
 
       const bodyText = await response.text();


### PR DESCRIPTION
## Summary

- Use a shared `httpx.AsyncClient` instance with connection pooling in Python `GasFreeAPIClient`, instead of creating a new TCP connection per request (especially impactful during `wait_for_success` polling)
- Add 30s HTTP timeout to all API requests in both TypeScript (`AbortSignal.timeout`) and Python (`httpx.AsyncClient(timeout=30.0)`) to prevent hanging on unresponsive proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)