### PR TITLE
feat: seller receipt signing (EIP-191) for PurchaseLog

### DIFF
--- a/python/x402/src/bankofai/x402/fastapi/__init__.py
+++ b/python/x402/src/bankofai/x402/fastapi/__init__.py
@@ -3,5 +3,6 @@ FastAPI middleware for x402 payment handling
 """
 
 from bankofai.x402.fastapi.middleware import X402Middleware, x402_protected
+from bankofai.x402.utils.receipt_signer import SellerSigningConfig
 
-__all__ = ["X402Middleware", "x402_protected"]
+__all__ = ["X402Middleware", "x402_protected", "SellerSigningConfig"]

--- a/python/x402/src/bankofai/x402/fastapi/middleware.py
+++ b/python/x402/src/bankofai/x402/fastapi/middleware.py
@@ -10,10 +10,11 @@ from fastapi.responses import JSONResponse
 
 from bankofai.x402.encoding import decode_payment_payload, encode_payment_payload
 from bankofai.x402.server import ResourceConfig, X402Server
-from bankofai.x402.types import PaymentPayload, PaymentRequirements
+from bankofai.x402.types import PaymentPayload, PaymentRequirements, ReceiptSignatureData
 from bankofai.x402.utils.address import checksum_evm_address
 
 if TYPE_CHECKING:
+    from bankofai.x402.utils.receipt_signer import SellerSigningConfig
     from bankofai.x402.utils.tx_verification import TransactionVerificationResult
 
 PAYMENT_SIGNATURE_HEADER = "PAYMENT-SIGNATURE"
@@ -50,6 +51,7 @@ class X402Middleware:
         pay_to: str | None = None,
         valid_for: int = 3600,
         delivery_mode: str = "PAYMENT_ONLY",
+        seller_signing: "SellerSigningConfig | None" = None,
     ) -> Callable:
         """
         Decorator to protect endpoints with payment requirements.
@@ -79,6 +81,10 @@ class X402Middleware:
             pay_to: Payment recipient address
             valid_for: Payment validity period (seconds)
             delivery_mode: Delivery mode
+            seller_signing: Optional SellerSigningConfig. When provided, the server
+                constructs and returns an ECDSA receipt signature (EIP-191) alongside
+                the data response. The buyer can submit this signature on-chain to
+                PurchaseLog.logPurchase() as proof of purchase.
 
         Returns:
             Decorated function
@@ -191,6 +197,27 @@ class X402Middleware:
                             status_code=500,
                         )
 
+                # Sign receipt if seller_signing is configured
+                if seller_signing and settle_result.transaction:
+                    import hashlib
+
+                    # paymentHash = SHA-256 of the PAYMENT-SIGNATURE header
+                    # (the buyer's base64-encoded payment payload). This matches
+                    # PurchaseLog.sol's spec: "SHA-256 of x402 X-Payment header".
+                    payment_hash_bytes = hashlib.sha256(
+                        payment_header.encode("utf-8")
+                    ).hexdigest()
+
+                    receipt_sig = self._sign_receipt(
+                        request=request,
+                        signing_config=seller_signing,
+                        payment_hash=payment_hash_bytes,
+                        amount=requirements.amount,
+                        network=requirements.network,
+                    )
+                    if receipt_sig:
+                        settle_result.receipt_signature = receipt_sig
+
                 response = await func(request, *args, **kwargs)
 
                 if isinstance(response, Response):
@@ -208,6 +235,67 @@ class X402Middleware:
             return wrapper
 
         return decorator
+
+    @staticmethod
+    def _sign_receipt(
+        request: Request,
+        signing_config: "SellerSigningConfig",
+        payment_hash: str,
+        amount: str,
+        network: str,
+    ) -> ReceiptSignatureData | None:
+        """Construct and sign the receipt digest for PurchaseLog verification.
+
+        Returns None if signing fails (logs a warning but does not block the response).
+        """
+        import logging
+
+        from bankofai.x402.config import NetworkConfig
+        from bankofai.x402.utils.receipt_signer import sign_receipt
+
+        logger = logging.getLogger(__name__)
+
+        try:
+            # Read buyer agent ID from request header (0 = anonymous)
+            buyer_agent_id = 0
+            header_val = request.headers.get(signing_config.buyer_agent_id_header)
+            if header_val:
+                buyer_agent_id = int(header_val)
+
+            # Validate values fit in the PurchaseLog's packed struct types
+            _UINT32_MAX = 2**32 - 1
+            if signing_config.listing_id > _UINT32_MAX:
+                logger.warning("listing_id %d exceeds uint32", signing_config.listing_id)
+                return None
+            if buyer_agent_id > _UINT32_MAX:
+                logger.warning("buyer_agent_id %d exceeds uint32", buyer_agent_id)
+                return None
+
+            chain_id = NetworkConfig.get_chain_id(network)
+
+            result = sign_receipt(
+                private_key=signing_config.private_key,
+                listing_id=signing_config.listing_id,
+                buyer_agent_id=buyer_agent_id,
+                payment_hash=payment_hash,
+                amount=amount,
+                chain_id=chain_id,
+                contract_address=signing_config.purchase_log_address,
+            )
+
+            return ReceiptSignatureData(
+                signature=result.signature,
+                digest=result.digest,
+                listingId=result.listing_id,
+                buyerAgentId=result.buyer_agent_id,
+                paymentHash=result.payment_hash,
+                amount=result.amount,
+                chainId=result.chain_id,
+                contractAddress=result.contract_address,
+            )
+        except Exception as e:
+            logger.warning("Receipt signing failed: %s", e, exc_info=True)
+            return None
 
     @staticmethod
     def _match_config(
@@ -315,6 +403,7 @@ def x402_protected(
     schemes: list[str],
     network: str,
     pay_to: str,
+    seller_signing: "SellerSigningConfig | None" = None,
     **kwargs: Any,
 ) -> Callable:
     """
@@ -329,13 +418,18 @@ def x402_protected(
             pay_to="T...",
         )
 
-    Multiple tokens, per-token scheme:
+    With seller receipt signing (for PurchaseLog on-chain proof):
         @x402_protected(
             server,
-            prices=["0.0001 USDT", "0.0001 DHLU"],
-            schemes=["exact_permit", "exact"],
-            network="eip155:97",
-            pay_to="0x...",
+            prices=["1 USDT"],
+            schemes=["exact_permit"],
+            network="tron:nile",
+            pay_to="T...",
+            seller_signing=SellerSigningConfig(
+                private_key="0x...",
+                listing_id=42,
+                purchase_log_address="0x...",
+            ),
         )
     """
     middleware = X402Middleware(server)
@@ -344,5 +438,6 @@ def x402_protected(
         schemes=schemes,
         network=network,
         pay_to=pay_to,
+        seller_signing=seller_signing,
         **kwargs,
     )

--- a/python/x402/src/bankofai/x402/server/x402_server.py
+++ b/python/x402/src/bankofai/x402/server/x402_server.py
@@ -257,7 +257,7 @@ class X402Server:
                     kind=PAYMENT_ONLY,
                     paymentId=payment_id or generate_payment_id(),
                     nonce=nonce or str(uuid.uuid4().int),
-                    validAfter=valid_after or now,
+                    validAfter=valid_after or (now - 60),
                     validBefore=valid_before or (now + 3600),
                 ),
             )

--- a/python/x402/src/bankofai/x402/types.py
+++ b/python/x402/src/bankofai/x402/types.py
@@ -199,6 +199,26 @@ class TransactionInfo(BaseModel):
         populate_by_name = True
 
 
+class ReceiptSignatureData(BaseModel):
+    """Seller's ECDSA receipt signature for on-chain purchase logging.
+
+    The seller signs a receipt digest using EIP-191 personal-sign so the buyer
+    can call PurchaseLog.logPurchase() with this signature as proof of purchase.
+    """
+
+    signature: str  # 0x-prefixed 65-byte ECDSA signature (r+s+v)
+    digest: str  # 0x-prefixed 32-byte keccak256 digest
+    listing_id: int = Field(alias="listingId")
+    buyer_agent_id: int = Field(alias="buyerAgentId")
+    payment_hash: str = Field(alias="paymentHash")  # 0x-prefixed bytes32
+    amount: int
+    chain_id: int = Field(alias="chainId")
+    contract_address: str = Field(alias="contractAddress")  # PurchaseLog address
+
+    class Config:
+        populate_by_name = True
+
+
 class SettleResponse(BaseModel):
     """Settlement response from facilitator"""
 
@@ -206,6 +226,9 @@ class SettleResponse(BaseModel):
     transaction: Optional[str] = None
     network: Optional[str] = None
     error_reason: Optional[str] = Field(None, alias="errorReason")
+    receipt_signature: Optional[ReceiptSignatureData] = Field(
+        None, alias="receiptSignature"
+    )
 
     class Config:
         populate_by_name = True

--- a/python/x402/src/bankofai/x402/utils/__init__.py
+++ b/python/x402/src/bankofai/x402/utils/__init__.py
@@ -11,6 +11,12 @@ from bankofai.x402.utils.eip712 import (
     payment_id_to_bytes,
 )
 from bankofai.x402.utils.payment_id import generate_payment_id
+from bankofai.x402.utils.receipt_signer import (
+    ReceiptSignature,
+    SellerSigningConfig,
+    compute_receipt_digest,
+    sign_receipt,
+)
 from bankofai.x402.utils.tron_verification import TronTransactionVerifier
 from bankofai.x402.utils.tx_verification import (
     BaseTransactionVerifier,
@@ -36,4 +42,9 @@ __all__ = [
     "BaseTransactionVerifier",
     "TronTransactionVerifier",
     "get_verifier_for_network",
+    # Receipt signing
+    "ReceiptSignature",
+    "SellerSigningConfig",
+    "compute_receipt_digest",
+    "sign_receipt",
 ]

--- a/python/x402/src/bankofai/x402/utils/receipt_signer.py
+++ b/python/x402/src/bankofai/x402/utils/receipt_signer.py
@@ -1,0 +1,208 @@
+"""
+Seller receipt signing for x402 protocol.
+
+Constructs and signs ECDSA receipt digests compatible with the PurchaseLog
+contract's signature verification. The seller signs the digest using Ethereum
+personal-sign (EIP-191) so the buyer can submit it on-chain as proof of purchase.
+
+Digest format (must match PurchaseLog._recoverSigner):
+    digest = keccak256(abi.encode(listingId, buyerAgentId, paymentHash, amount, chainId, contractAddress))
+    prefixedHash = keccak256("\x19Ethereum Signed Message:\n32" || digest)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from eth_abi import encode as abi_encode
+from Crypto.Hash import keccak as pycryptodome_keccak
+
+logger = logging.getLogger(__name__)
+
+
+def _keccak256(data: bytes) -> bytes:
+    """Compute keccak256 hash."""
+    k = pycryptodome_keccak.new(digest_bits=256)
+    k.update(data)
+    return k.digest()
+
+
+def _to_bytes32(value: str | bytes | int) -> bytes:
+    """Convert a value to a 32-byte representation."""
+    if isinstance(value, int):
+        return value.to_bytes(32, byteorder="big")
+    if isinstance(value, str):
+        if value.startswith("0x"):
+            value = value[2:]
+        return bytes.fromhex(value).rjust(32, b"\x00")
+    return value.rjust(32, b"\x00")
+
+
+def _to_uint256(value: int | str) -> int:
+    """Convert to uint256 integer."""
+    return int(value)
+
+
+def _to_address_hex(address: str) -> str:
+    """Convert an address string to 0x-prefixed hex for eth_abi address encoding."""
+    if address.startswith("0x") and len(address) == 42:
+        return address
+    # TRON address — convert to EVM hex first
+    from bankofai.x402.utils.address import tron_address_to_evm
+
+    return tron_address_to_evm(address)
+
+
+@dataclass
+class ReceiptSignature:
+    """Seller's ECDSA signature over a receipt digest."""
+
+    signature: str  # 0x-prefixed hex, 65 bytes (r+s+v)
+    digest: str  # 0x-prefixed hex, 32 bytes
+    listing_id: int
+    buyer_agent_id: int
+    payment_hash: str  # 0x-prefixed hex
+    amount: int
+    chain_id: int
+    contract_address: str  # 0x-prefixed hex
+
+
+def compute_receipt_digest(
+    listing_id: int,
+    buyer_agent_id: int,
+    payment_hash: bytes,
+    amount: int,
+    chain_id: int,
+    contract_address: str,
+) -> bytes:
+    """
+    Compute the receipt digest exactly as PurchaseLog.sol does:
+        keccak256(abi.encode(listingId, buyerAgentId, paymentHash, amount, block.chainid, address(this)))
+
+    Args:
+        listing_id: Listing ID in DataMarketplace.
+        buyer_agent_id: 8004 agent ID of the buyer (0 for anonymous).
+        payment_hash: 32-byte payment hash (SHA-256 of x402 X-Payment header).
+        amount: Payment amount in token smallest unit.
+        chain_id: EVM chain ID.
+        contract_address: PurchaseLog contract address (0x-prefixed hex).
+
+    Returns:
+        32-byte keccak256 digest.
+    """
+    contract_addr_hex = _to_address_hex(contract_address)
+
+    # abi.encode(uint256, uint256, bytes32, uint256, uint256, address)
+    encoded = abi_encode(
+        ["uint256", "uint256", "bytes32", "uint256", "uint256", "address"],
+        [
+            _to_uint256(listing_id),
+            _to_uint256(buyer_agent_id),
+            payment_hash,
+            _to_uint256(amount),
+            _to_uint256(chain_id),
+            contract_addr_hex,
+        ],
+    )
+
+    return _keccak256(encoded)
+
+
+def sign_receipt(
+    private_key: str,
+    listing_id: int,
+    buyer_agent_id: int,
+    payment_hash: str | bytes,
+    amount: int | str,
+    chain_id: int,
+    contract_address: str,
+) -> ReceiptSignature:
+    """
+    Sign a receipt digest using Ethereum personal-sign (EIP-191).
+
+    The resulting signature can be verified on-chain by PurchaseLog.logPurchase().
+
+    Args:
+        private_key: Seller's private key (0x-prefixed hex).
+        listing_id: Listing ID in DataMarketplace.
+        buyer_agent_id: 8004 agent ID of the buyer (0 for anonymous).
+        payment_hash: 32-byte payment hash as hex string or bytes.
+        amount: Payment amount in token smallest unit.
+        chain_id: EVM chain ID.
+        contract_address: PurchaseLog contract address.
+
+    Returns:
+        ReceiptSignature with the 65-byte ECDSA signature and metadata.
+    """
+    amount_int = int(amount)
+
+    if isinstance(payment_hash, str):
+        if payment_hash.startswith("0x"):
+            payment_hash_bytes = bytes.fromhex(payment_hash[2:])
+        else:
+            payment_hash_bytes = bytes.fromhex(payment_hash)
+    else:
+        payment_hash_bytes = payment_hash
+
+    # Pad to 32 bytes if needed
+    payment_hash_bytes = payment_hash_bytes.rjust(32, b"\x00")
+
+    digest = compute_receipt_digest(
+        listing_id=listing_id,
+        buyer_agent_id=buyer_agent_id,
+        payment_hash=payment_hash_bytes,
+        amount=amount_int,
+        chain_id=chain_id,
+        contract_address=contract_address,
+    )
+
+    # EIP-191 personal sign: the wallet signs the raw digest bytes, and
+    # encode_defunct applies the "\x19Ethereum Signed Message:\n32" prefix.
+    signable = encode_defunct(primitive=digest)
+    signed = Account.sign_message(signable, private_key=private_key)
+
+    sig_hex = "0x" + signed.signature.hex()
+
+    logger.info(
+        "Signed receipt: listing=%d buyer_agent=%d amount=%d chain=%d",
+        listing_id,
+        buyer_agent_id,
+        amount_int,
+        chain_id,
+    )
+
+    return ReceiptSignature(
+        signature=sig_hex,
+        digest="0x" + digest.hex(),
+        listing_id=listing_id,
+        buyer_agent_id=buyer_agent_id,
+        payment_hash="0x" + payment_hash_bytes.hex(),
+        amount=amount_int,
+        chain_id=chain_id,
+        contract_address=contract_address,
+    )
+
+
+@dataclass
+class SellerSigningConfig:
+    """Configuration for seller receipt signing.
+
+    Attach this to a protected endpoint so the middleware knows how to
+    construct and sign the receipt digest after settlement.
+
+    Args:
+        private_key: Seller's private key (0x-prefixed hex).
+        listing_id: Listing ID in DataMarketplace.
+        purchase_log_address: PurchaseLog contract address.
+        buyer_agent_id_header: HTTP header name that carries the buyer's agent ID.
+            If the header is absent, buyer_agent_id defaults to 0 (anonymous).
+    """
+
+    private_key: str
+    listing_id: int
+    purchase_log_address: str
+    buyer_agent_id_header: str = "X-Buyer-Agent-Id"

--- a/typescript/packages/x402/src/types/responses.ts
+++ b/typescript/packages/x402/src/types/responses.ts
@@ -39,6 +39,26 @@ export interface VerifyResponse {
   invalidReason?: string;
 }
 
+/** Seller's ECDSA receipt signature for on-chain purchase logging */
+export interface ReceiptSignatureData {
+  /** 0x-prefixed 65-byte ECDSA signature (r+s+v) */
+  signature: string;
+  /** 0x-prefixed 32-byte keccak256 digest */
+  digest: string;
+  /** Listing ID in DataMarketplace */
+  listingId: number;
+  /** 8004 agent ID of the buyer (0 = anonymous) */
+  buyerAgentId: number;
+  /** 0x-prefixed bytes32 payment hash */
+  paymentHash: string;
+  /** Payment amount in token smallest unit */
+  amount: number;
+  /** EVM chain ID */
+  chainId: number;
+  /** PurchaseLog contract address */
+  contractAddress: string;
+}
+
 /** Settlement response from facilitator */
 export interface SettleResponse {
   /** Whether settlement succeeded */
@@ -49,6 +69,8 @@ export interface SettleResponse {
   network?: string;
   /** Error reason (if failed) */
   errorReason?: string;
+  /** Seller receipt signature for PurchaseLog on-chain proof */
+  receiptSignature?: ReceiptSignatureData;
 }
 
 /** Supported response from facilitator */


### PR DESCRIPTION
## Summary

- **New `receipt_signer.py`**: Implements `compute_receipt_digest()` and `sign_receipt()` for EIP-191 personal-sign over `keccak256(abi.encode(listingId, buyerAgentId, paymentHash, amount, chainId, contractAddress))`, matching `PurchaseLog.sol`'s on-chain verification.
- **FastAPI middleware**: Adds optional `SellerSigningConfig` parameter to `x402_protected()`. After successful settlement, the middleware auto-signs a receipt and includes it in the `PAYMENT-RESPONSE` header as `receiptSignature`.
- **`paymentHash` = SHA-256 of `PAYMENT-SIGNATURE` header**: The payment hash is derived from the buyer's raw payment header (not the settlement tx hash), ensuring a cryptographic binding between the x402 payment and the on-chain purchase record.
- **TypeScript + Python types**: `ReceiptSignatureData` added to both SDKs' `SettleResponse`.
- **Timing fix**: `validAfter = now - 60` to prevent facilitator `not_yet_valid` race conditions.

## Security

- **uint32 overflow validation** on `listingId` and `buyerAgentId` before signing
- **EIP-191 envelope** prevents cross-protocol signature reuse
- **`chainId` + `address(this)`** in digest prevents cross-chain / cross-contract replay
- **`s ≤ half-order`** enforced by eth-account's signing library (malleability guard)

## Usage

```python
from bankofai.x402.fastapi import x402_protected, SellerSigningConfig

signing = SellerSigningConfig(
    private_key="<seller-hex-key>",
    listing_id=5,
    purchase_log_address="<PurchaseLog-contract-address>",
)

@app.get("/data")
@x402_protected(requirements, seller_signing=signing)
async def get_data(request: Request):
    return {"data": "premium content"}
```

## Test plan

- [x] Full e2e on TRON Nile: agent registration → listing → x402 purchase → PurchaseLog.logPurchase() → `verified: true`
- [x] Verified `paymentHash` matches across seller middleware, buyer receipt, and on-chain submission
- [x] Confirmed receipt signature recovers to seller address on-chain