### PR TITLE
fix(python): preserve raw_data_hex in tron approvals

### DIFF
--- a/python/x402/src/bankofai/x402/signers/client/tron_signer.py
+++ b/python/x402/src/bankofai/x402/signers/client/tron_signer.py
@@ -61,6 +61,38 @@ class TronClientSigner(ClientSigner):
             result = sigs[0]
         return result
 
+    @staticmethod
+    def _build_unsigned_tx_payload(txn: Any) -> dict[str, Any]:
+        """Build an unsigned TRON tx payload compatible with agent-wallet."""
+        payload: dict[str, Any] = txn.to_json() if hasattr(txn, "to_json") else {}
+
+        txid = payload.get("txID")
+        if not txid:
+            txid = getattr(txn, "txid", None) or getattr(txn, "txID", None)
+        if txid:
+            payload["txID"] = txid
+
+        raw_data_hex = payload.get("raw_data_hex")
+        if not raw_data_hex:
+            raw_data_hex = getattr(txn, "raw_data_hex", None)
+        if not raw_data_hex:
+            maybe = getattr(txn, "_raw_data_hex", None)
+            if callable(maybe):
+                try:
+                    raw_data_hex = maybe()
+                except Exception:
+                    raw_data_hex = None
+        if raw_data_hex:
+            payload["raw_data_hex"] = raw_data_hex
+
+        unsigned: dict[str, Any] = {
+            "txID": payload.get("txID"),
+            "raw_data_hex": payload.get("raw_data_hex"),
+        }
+        if payload.get("raw_data") is not None:
+            unsigned["raw_data"] = payload.get("raw_data")
+        return unsigned
+
     def _ensure_async_tron_client(self, network: str) -> Any:
         """Lazy initialize async tron_client for the given network.
 
@@ -248,8 +280,8 @@ class TronClientSigner(ClientSigner):
             txn_builder = txn_builder.with_owner(owner_address).fee_limit(100_000_000)
             txn = await txn_builder.build()
             # Sign the transaction via wallet
-            txn_dict = txn.to_json()
-            raw_result = await self._wallet.sign_transaction(txn_dict)
+            unsigned_payload = self._build_unsigned_tx_payload(txn)
+            raw_result = await self._wallet.sign_transaction(unsigned_payload)
             sig_hex = self._extract_tron_signature(raw_result)
             txn._signature = [sig_hex]
             logger.info("Broadcasting approval transaction...")

--- a/python/x402/tests/client/test_signers.py
+++ b/python/x402/tests/client/test_signers.py
@@ -90,6 +90,52 @@ async def test_tron_signer_check_allowance():
 
 
 @pytest.mark.anyio
+async def test_tron_signer_ensure_allowance_builds_agent_wallet_payload():
+    """Test TRON approval signs a payload containing raw_data_hex."""
+    wallet = MagicMock()
+    wallet.get_address = AsyncMock(return_value="TTestBuyerAddress")
+    wallet.sign_transaction = AsyncMock(return_value='{"signature":["' + ("ab" * 65) + '"]}')
+
+    provider = MagicMock()
+    provider.get_active_wallet = AsyncMock(return_value=wallet)
+
+    with patch("agent_wallet.resolve_wallet_provider", return_value=provider):
+        signer = await TronClientSigner.create()
+
+    signer.check_allowance = AsyncMock(return_value=0)
+    signer._get_spender_address = MagicMock(return_value="TSpenderAddress")
+
+    broadcast_result = MagicMock()
+    broadcast_result.wait = AsyncMock(return_value={"receipt": {"result": "SUCCESS"}, "id": "txid"})
+
+    txn = MagicMock()
+    txn.to_json.return_value = {"txID": "txid", "raw_data": {"fee_limit": 100000000}}
+    txn.raw_data_hex = "deadbeef"
+    txn.broadcast = AsyncMock(return_value=broadcast_result)
+
+    txn_builder = MagicMock()
+    txn_builder.with_owner.return_value = txn_builder
+    txn_builder.fee_limit.return_value = txn_builder
+    txn_builder.build = AsyncMock(return_value=txn)
+
+    contract = MagicMock()
+    contract.functions.approve = AsyncMock(return_value=txn_builder)
+
+    client = MagicMock()
+    client.get_contract = AsyncMock(return_value=contract)
+    signer._ensure_async_tron_client = MagicMock(return_value=client)
+
+    assert await signer.ensure_allowance("TTestToken", 1000000, "tron:nile") is True
+    wallet.sign_transaction.assert_awaited_once_with(
+        {
+            "txID": "txid",
+            "raw_data_hex": "deadbeef",
+            "raw_data": {"fee_limit": 100000000},
+        }
+    )
+
+
+@pytest.mark.anyio
 async def test_evm_signer_check_allowance():
     """Test EVM signer allowance check propagates contract failures"""
     wallet = MagicMock()


### PR DESCRIPTION
Fixes #64

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `/python/x402` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm lint` from `/typescript`
For Python: Run `uvx ruff check && uvx ruff format --check` from `/python/x402`
-->
