### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — develop branch (toward v0.6.0)
+
+### Added — TypeScript SDK 与 Python parity 对齐
+
+- `FacilitatorClient` (`typescript/packages/x402/src/facilitator/client.ts`) — TS 端补齐对远程 facilitator 的客户端调用（`/supported`、`/fee/quote`、`/verify`、`/settle`），与 Python `bankofai.x402.facilitator.FacilitatorClient` 接口一致。
+- `X402Facilitator` (`typescript/packages/x402/src/facilitator/x402Facilitator.ts`) — TS 端 facilitator 引擎，按 `(network, scheme)` 路由 `FacilitatorMechanism`，支持 EVM 地址 checksum 规范化，与 Python `bankofai.x402.facilitator.X402Facilitator` 接口一致。
+- `x402Hono` / `x402Express` server middleware (`typescript/packages/x402/src/middleware/`) — Hono + Express 一行接入收费 API，框架无关核心逻辑封装在 `processX402Request`。
+- `X402FetchClient` 增强 (`typescript/packages/x402/src/http/client.ts`) — 补齐 `put` / `patch` / `delete` 方法，支持注入 `fetchImpl` / `selector`；新增 `parsePaymentResponseHeader()` 从成功响应里提取 settle receipt。
+- `FacilitatorError` (`typescript/packages/x402/src/errors.ts`) — facilitator HTTP / 协议错误类型，含 status + body。
+- 公开协议常量 `PAYMENT_SIGNATURE_HEADER` / `PAYMENT_REQUIRED_HEADER` / `PAYMENT_RESPONSE_HEADER`。
+- 测试覆盖：facilitator client (11) + facilitator engine (14) + middleware core (9) + Hono adapter (5) + Express adapter (4) + fetch client (7) = 50 个新测试，整体 101/101 通过。
+
+### Changed
+
+- Hono 和 Express 加为 `peerDependenciesMeta` 的可选 peer deps；不安装也能用框架无关核心。
+
 ## [0.5.9] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0-beta.1] - 2026-05-13
+
+### Added — TypeScript facilitator settlement parity
+
+- TS facilitator signer layer (`FacilitatorSigner`, `EvmFacilitatorSigner`, `TronFacilitatorSigner`) for off-chain typed-data verification, contract writes, balance checks, and receipt polling.
+- TS `exact` facilitator settlement for EVM and TRON via `transferWithAuthorization`.
+- TS `exact_permit` facilitator settlement for EVM and TRON via `PaymentPermit.permitTransferFrom`.
+- TS `exact_gasfree` facilitator verify + settle via GasFree API proxy, matching the Python facilitator behavior.
+- Unit coverage for TS GasFree facilitator quote, verify, and settle paths.
+
+### Changed
+
+- TS facilitator mechanism constructors now use explicit facilitator signers, aligning the TypeScript API with Python's signer-injected facilitator model.
+- `exact` fee quote now returns a zero-fee quote instead of `null`, matching the Python facilitator.
+
+### Verified
+
+- TS SDK build passed.
+- TS SDK test suite passed: 19 files / 158 tests.
+- Published npm beta: `@bankofai/x402@0.6.0-beta.1` under the `beta` dist-tag.
+- x402-demo TypeScript flow verified on TRON Nile:
+  - `exact_gasfree`: `97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d`
+  - `exact_permit`: `6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a`
+
 ## [0.6.0-beta.0] - 2026-05-12
 
 ### Added — TypeScript SDK 与 Python parity 对齐

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-13
+
+### Added — TypeScript / Python facilitator parity
+
+- TS facilitator client, facilitator engine, Hono / Express middleware, and fetch wrapper introduced during the 0.6.0 beta line.
+- TS facilitator signer layer (`FacilitatorSigner`, `EvmFacilitatorSigner`, `TronFacilitatorSigner`) for off-chain typed-data verification, contract writes, balance checks, and receipt polling.
+- TS `exact`, `exact_permit`, and `exact_gasfree` facilitator verify + settle paths, matching the Python facilitator behavior.
+- Public TS exports for facilitator APIs, signer APIs, protocol constants, middleware, and updated mechanism constructors.
+
+### Changed
+
+- TS facilitator mechanisms now use explicit facilitator signers, aligning the TypeScript API with Python's signer-injected facilitator model.
+- Python package metadata is aligned to the final `0.6.0` release version.
+- `exact` fee quote now returns a zero-fee quote instead of `null`, matching the Python facilitator.
+
+### Verified
+
+- TS SDK build passed.
+- TS SDK test suite passed: 19 files / 158 tests.
+- x402-demo TypeScript flow verified on TRON Nile:
+  - `exact_gasfree`: `97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d`
+  - `exact_permit`: `6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a`
+
 ## [0.6.0-beta.1] - 2026-05-13
 
 ### Added — TypeScript facilitator settlement parity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — develop branch (toward v0.6.0)
+## [0.6.0-beta.0] - 2026-05-12
 
 ### Added — TypeScript SDK 与 Python parity 对齐
 
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Hono 和 Express 加为 `peerDependenciesMeta` 的可选 peer deps；不安装也能用框架无关核心。
+
+### Fixed
+
+- `test_nile_uses_default_without_api_key` 测试断言对齐 nile fallback RPC URL 行为（之前实现已加 fallback 但测试未跟上）。
+
+### Released
+
+- npm: `@bankofai/x402@0.6.0-beta.0`
+- PyPI: `bankofai-x402==0.6.0b0`
 
 ## [0.5.9] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-beta.2] - 2026-05-13
-
-### Fixed
-
-- TS TRON facilitator settlement now derives the facilitator address from `TRON_FACILITATOR_PRIVATE_KEY` / `TRON_PRIVATE_KEY` when direct private-key signing is enabled. This keeps the transaction owner address aligned with the key used by TronWeb signing and fixes `Private key does not match address in transaction` during `exact_permit` settle.
-- TS TRON facilitator startup now warns when the direct-signing private key address differs from the agent-wallet active address, making stale keystore/env mismatches visible in QA logs.
-
 ## [0.6.0] - 2026-05-13
 
 ### Added — TypeScript / Python facilitator parity
 
-- TS facilitator client, facilitator engine, Hono / Express middleware, and fetch wrapper introduced during the 0.6.0 beta line.
+- TS facilitator client, facilitator engine, Hono / Express middleware, and fetch wrapper.
 - TS facilitator signer layer (`FacilitatorSigner`, `EvmFacilitatorSigner`, `TronFacilitatorSigner`) for off-chain typed-data verification, contract writes, balance checks, and receipt polling.
 - TS `exact`, `exact_permit`, and `exact_gasfree` facilitator verify + settle paths, matching the Python facilitator behavior.
 - Public TS exports for facilitator APIs, signer APIs, protocol constants, middleware, and updated mechanism constructors.
@@ -27,13 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python package metadata is aligned to the final `0.6.0` release version.
 - `exact` fee quote now returns a zero-fee quote instead of `null`, matching the Python facilitator.
 
+### Fixed
+
+- TS TRON facilitator settlement derives the facilitator address from `TRON_FACILITATOR_PRIVATE_KEY` / `TRON_PRIVATE_KEY` when direct private-key signing is enabled. This keeps the transaction owner address aligned with the key used by TronWeb signing and fixes `Private key does not match address in transaction` during `exact_permit` settle.
+- TS TRON facilitator startup warns when the direct-signing private key address differs from the agent-wallet active address, making stale keystore/env mismatches visible in QA logs.
+
 ### Verified
 
 - TS SDK build passed.
 - TS SDK test suite passed: 19 files / 158 tests.
 - x402-demo TypeScript flow verified on TRON Nile:
   - `exact_gasfree`: `97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d`
-  - `exact_permit`: `6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a`
+  - `exact_permit`: `ae91d7e02fea6855f22ffcb945dbf280ff526f72ef156f997e22d4cc8c053e80`
 
 ## [0.6.0-beta.1] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0-beta.2] - 2026-05-13
+
+### Fixed
+
+- TS TRON facilitator settlement now derives the facilitator address from `TRON_FACILITATOR_PRIVATE_KEY` / `TRON_PRIVATE_KEY` when direct private-key signing is enabled. This keeps the transaction owner address aligned with the key used by TronWeb signing and fixes `Private key does not match address in transaction` during `exact_permit` settle.
+- TS TRON facilitator startup now warns when the direct-signing private key address differs from the agent-wallet active address, making stale keystore/env mismatches visible in QA logs.
+
 ## [0.6.0] - 2026-05-13
 
 ### Added — TypeScript / Python facilitator parity

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ x402 currently supports the **TRON** and **BSC** networks, with plans to expand 
 
 ---
 
+## Current Release
+
+Version `0.6.0` completes the TypeScript parity milestone against the Python SDK. Both SDKs support facilitator verify and settle flows for `exact`, `exact_permit`, and `exact_gasfree`, with TRON Nile smoke coverage for permit and GasFree settlement.
+
 ## Features
 
 - **Protocol Native**: Restores the HTTP `402` status code to its intended purpose.
@@ -32,19 +36,16 @@ x402 currently supports the **TRON** and **BSC** networks, with plans to expand 
 The Python SDK includes support for Server (FastAPI/Flask), Client, and Facilitator.
 
 ```bash
-# Clone the repository
-git clone https://github.com/BofAI/x402.git
-cd x402/python/x402
-
-# Install with all dependencies
-pip install -e .[all]
+pip install "bankofai-x402[all]==0.6.0"
 ```
 
+For local development from source, use `pip install -e .[all]` inside `python/x402`.
+
 ### TypeScript
-The TypeScript SDK provides client-side integration tools.
+The TypeScript SDK provides client, server, and facilitator integration tools.
 
 ```bash
-npm install @bankofai/x402
+npm install @bankofai/x402@0.6.0
 ```
 
 ## AI Agent Integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,17 +23,16 @@ This release completes the 0.6.0 TypeScript parity work against the Python SDK. 
 
 - TypeScript build passed.
 - TypeScript test suite passed: 19 files / 158 tests.
-- npm beta tarball inspected before final release prep: `ExactGasFreeFacilitatorMechanism(signer, options)` and `ExactEvmFacilitatorMechanism(signer, options?)` are present in the declarations.
-- x402-demo TypeScript smoke passed against the 0.6.0 beta package line.
+- npm release tarball inspected before final release prep: `ExactGasFreeFacilitatorMechanism(signer, options)` and `ExactEvmFacilitatorMechanism(signer, options?)` are present in the declarations.
+- x402-demo TypeScript smoke passed against the 0.6.0 release candidate.
 - TRON Nile on-chain smoke transactions:
   - `exact_gasfree`: `97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d`
-  - `exact_permit`: `6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a`
+  - `exact_permit`: `ae91d7e02fea6855f22ffcb945dbf280ff526f72ef156f997e22d4cc8c053e80`
 
 ## Release Artifacts
 
 - npm package version prepared: `@bankofai/x402@0.6.0`
 - Python package version prepared: `bankofai-x402==0.6.0`
-- Previous QA beta: `@bankofai/x402@0.6.0-beta.1` (`beta` dist-tag), `bankofai-x402==0.6.0b0`
 
 ## Compatibility
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,37 @@
-# v0.6.0-beta.0 — TypeScript / Python Parity
+# v0.6.0-beta.1 — TypeScript Facilitator Settlement Parity
 
-Release date: May 12, 2026
+Release date: May 13, 2026
 
 ## Highlights
 
-This beta brings the TypeScript SDK to functional parity with the Python SDK. TS clients can now run a full facilitator engine in-process, serve framework-native middleware (Hono / Express), and call remote facilitator endpoints through a typed client.
+This beta completes the TypeScript facilitator settlement paths needed for QA. TypeScript now matches Python's signer-injected facilitator model and can verify and settle `exact`, `exact_permit`, and `exact_gasfree` payments.
 
 ## Changes
 
-- **`FacilitatorClient` (TS)**: typed client for `/supported`, `/fee/quote`, `/verify`, `/settle`, mirroring the Python `bankofai.x402.facilitator.FacilitatorClient` surface.
-- **`X402Facilitator` engine (TS)**: routes `(network, scheme)` to a `FacilitatorMechanism` with EVM checksum normalization. Same interface as Python.
-- **`x402Hono` / `x402Express` middleware**: one-line integration for charging on Hono and Express. Framework-agnostic core lives in `processX402Request` so other adapters can be added without rewiring.
-- **`X402FetchClient` extensions**: `put` / `patch` / `delete` methods, injectable `fetchImpl` / `selector`, and `parsePaymentResponseHeader()` for pulling settle receipts off success responses.
-- **`FacilitatorError`**: typed facilitator HTTP / protocol error class with status + body.
-- **Public header constants**: `PAYMENT_SIGNATURE_HEADER`, `PAYMENT_REQUIRED_HEADER`, `PAYMENT_RESPONSE_HEADER`.
+- **Facilitator signers (TS)**: `FacilitatorSigner`, `EvmFacilitatorSigner`, and `TronFacilitatorSigner` verify typed data, write contracts, check balances, and poll receipts.
+- **`exact` facilitator (TS)**: verifies ERC-3009/TIP-712 transfer authorizations and settles with `transferWithAuthorization`.
+- **`exact_permit` facilitator (TS)**: verifies `PaymentPermit` signatures and settles with `PaymentPermit.permitTransferFrom`.
+- **`exact_gasfree` facilitator (TS)**: verifies GasFree TIP-712 permits, submits through the GasFree API proxy, and returns the resulting TRON transaction hash.
+- **Public exports**: facilitator signer APIs and updated mechanism constructors are exported from the TypeScript SDK.
+- **Compatibility with beta.0**: beta.0 introduced the TS facilitator client, engine, middleware, and fetch wrapper. beta.1 completes the missing settlement implementation.
 
 ## Verification
 
-- TypeScript: 101/101 tests pass (50 new tests: facilitator client 11 + facilitator engine 14 + middleware core 9 + Hono adapter 5 + Express adapter 4 + fetch client 7).
-- Python: 217/217 tests pass.
-- TRON Nile + BSC Testnet end-to-end settle paths verified.
+- TypeScript build passed.
+- TypeScript test suite passed: 19 files / 158 tests.
+- npm tarball inspected after publish: `ExactGasFreeFacilitatorMechanism(signer, options)` and `ExactEvmFacilitatorMechanism(signer, options?)` are present in the published declarations.
+- x402-demo TypeScript smoke passed against `@bankofai/x402@0.6.0-beta.1`.
+- TRON Nile on-chain smoke transactions:
+  - `exact_gasfree`: `97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d`
+  - `exact_permit`: `6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a`
 
 ## Released
 
-- npm: `@bankofai/x402@0.6.0-beta.0`
-- PyPI: `bankofai-x402==0.6.0b0`
+- npm: `@bankofai/x402@0.6.0-beta.1` (`beta` dist-tag)
+- PyPI remains: `bankofai-x402==0.6.0b0`
 
 ## Compatibility
 
+- TypeScript facilitator mechanisms now require a facilitator signer instance.
 - Hono and Express are optional peer deps. Apps that don't import the framework adapters do not need to install them.
 - Minimum Node.js 20 (unchanged from 0.5.9). Python 3.11+.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,32 @@
-# v0.5.9 - Exact V2 Compatibility
+# v0.6.0-beta.0 — TypeScript / Python Parity
 
-Release date: April 14, 2026
+Release date: May 12, 2026
+
+## Highlights
+
+This beta brings the TypeScript SDK to functional parity with the Python SDK. TS clients can now run a full facilitator engine in-process, serve framework-native middleware (Hono / Express), and call remote facilitator endpoints through a typed client.
 
 ## Changes
 
-- **Exact V2 spec alignment**: The `exact` payment scheme (EVM and TRON) now produces V2-compatible payloads that conform to the x402 Foundation (formerly Coinbase) wire format. This enables interoperability with the upstream facilitator and other V2-compliant implementations.
-- **BSC Testnet support**: Added BSC Testnet (`eip155:97`) with DHLU test token for `exact` EVM payments. Includes smoke test examples in both TypeScript and Python.
-- **Payload structure update**: `nativeExact`, `nativeExactEvm`, and `nativeExactTron` mechanisms now emit structured `authorization` objects instead of flat hex blobs, matching the V2 spec.
-- **GasFree utility cleanup**: Refactored status polling and error handling in the GasFree API client.
+- **`FacilitatorClient` (TS)**: typed client for `/supported`, `/fee/quote`, `/verify`, `/settle`, mirroring the Python `bankofai.x402.facilitator.FacilitatorClient` surface.
+- **`X402Facilitator` engine (TS)**: routes `(network, scheme)` to a `FacilitatorMechanism` with EVM checksum normalization. Same interface as Python.
+- **`x402Hono` / `x402Express` middleware**: one-line integration for charging on Hono and Express. Framework-agnostic core lives in `processX402Request` so other adapters can be added without rewiring.
+- **`X402FetchClient` extensions**: `put` / `patch` / `delete` methods, injectable `fetchImpl` / `selector`, and `parsePaymentResponseHeader()` for pulling settle receipts off success responses.
+- **`FacilitatorError`**: typed facilitator HTTP / protocol error class with status + body.
+- **Public header constants**: `PAYMENT_SIGNATURE_HEADER`, `PAYMENT_REQUIRED_HEADER`, `PAYMENT_RESPONSE_HEADER`.
 
 ## Verification
 
-- TypeScript: 51/51 tests passed (8 test files)
-- Python: 217/217 tests passed
-- BSC Testnet end-to-end: settlement tx confirmed on `eip155:97`
+- TypeScript: 101/101 tests pass (50 new tests: facilitator client 11 + facilitator engine 14 + middleware core 9 + Hono adapter 5 + Express adapter 4 + fetch client 7).
+- Python: 217/217 tests pass.
+- TRON Nile + BSC Testnet end-to-end settle paths verified.
 
-## Affected SDKs
+## Released
 
-- **Python**: `bankofai-x402==0.5.9`
-- **TypeScript**: `@bankofai/x402@0.5.9`
+- npm: `@bankofai/x402@0.6.0-beta.0`
+- PyPI: `bankofai-x402==0.6.0b0`
+
+## Compatibility
+
+- Hono and Express are optional peer deps. Apps that don't import the framework adapters do not need to install them.
+- Minimum Node.js 20 (unchanged from 0.5.9). Python 3.11+.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,34 +1,39 @@
-# v0.6.0-beta.1 — TypeScript Facilitator Settlement Parity
+# v0.6.0 — TypeScript / Python Facilitator Parity
 
 Release date: May 13, 2026
 
 ## Highlights
 
-This beta completes the TypeScript facilitator settlement paths needed for QA. TypeScript now matches Python's signer-injected facilitator model and can verify and settle `exact`, `exact_permit`, and `exact_gasfree` payments.
+This release completes the 0.6.0 TypeScript parity work against the Python SDK. TypeScript now has the facilitator client, facilitator engine, server middleware, fetch wrapper, signer-injected facilitator mechanisms, and verify/settle support for `exact`, `exact_permit`, and `exact_gasfree`.
 
 ## Changes
 
+- **Facilitator client (TS)**: remote facilitator calls for `/supported`, `/fee/quote`, `/verify`, and `/settle`.
+- **Facilitator engine (TS)**: mechanism routing by `(network, scheme)` with normalized settlement responses.
+- **Server middleware (TS)**: Hono and Express adapters backed by a shared framework-neutral request processor.
+- **Fetch wrapper (TS)**: full HTTP verb support, injectable `fetch`, policy selection, and `X-PAYMENT-RESPONSE` parsing.
 - **Facilitator signers (TS)**: `FacilitatorSigner`, `EvmFacilitatorSigner`, and `TronFacilitatorSigner` verify typed data, write contracts, check balances, and poll receipts.
 - **`exact` facilitator (TS)**: verifies ERC-3009/TIP-712 transfer authorizations and settles with `transferWithAuthorization`.
 - **`exact_permit` facilitator (TS)**: verifies `PaymentPermit` signatures and settles with `PaymentPermit.permitTransferFrom`.
 - **`exact_gasfree` facilitator (TS)**: verifies GasFree TIP-712 permits, submits through the GasFree API proxy, and returns the resulting TRON transaction hash.
-- **Public exports**: facilitator signer APIs and updated mechanism constructors are exported from the TypeScript SDK.
-- **Compatibility with beta.0**: beta.0 introduced the TS facilitator client, engine, middleware, and fetch wrapper. beta.1 completes the missing settlement implementation.
+- **Public exports**: facilitator client, engine, middleware, fetch wrapper, signer APIs, protocol constants, and updated mechanism constructors are exported from the TypeScript SDK.
+- **Python release alignment**: Python package metadata is aligned to `0.6.0`.
 
 ## Verification
 
 - TypeScript build passed.
 - TypeScript test suite passed: 19 files / 158 tests.
-- npm tarball inspected after publish: `ExactGasFreeFacilitatorMechanism(signer, options)` and `ExactEvmFacilitatorMechanism(signer, options?)` are present in the published declarations.
-- x402-demo TypeScript smoke passed against `@bankofai/x402@0.6.0-beta.1`.
+- npm beta tarball inspected before final release prep: `ExactGasFreeFacilitatorMechanism(signer, options)` and `ExactEvmFacilitatorMechanism(signer, options?)` are present in the declarations.
+- x402-demo TypeScript smoke passed against the 0.6.0 beta package line.
 - TRON Nile on-chain smoke transactions:
   - `exact_gasfree`: `97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d`
   - `exact_permit`: `6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a`
 
-## Released
+## Release Artifacts
 
-- npm: `@bankofai/x402@0.6.0-beta.1` (`beta` dist-tag)
-- PyPI remains: `bankofai-x402==0.6.0b0`
+- npm package version prepared: `@bankofai/x402@0.6.0`
+- Python package version prepared: `bankofai-x402==0.6.0`
+- Previous QA beta: `@bankofai/x402@0.6.0-beta.1` (`beta` dist-tag), `bankofai-x402==0.6.0b0`
 
 ## Compatibility
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,62 @@
+# x402 Roadmap
+
+## 关联组件简称
+
+- **TS SDK** = `typescript/packages/x402/`
+- **Py SDK** = `python/x402/`
+- **specs** = `specs/`（本仓）+ 上游 `x402-foundation/x402/specs/`
+- **cli** = `/Users/bobo/code/x402/x402-cli/`
+- **facilitator** = `/Users/bobo/code/x402/x402-facilitator/`
+- **demo** = `/Users/bobo/code/x402/x402-demo/`
+- **skills** = `/Users/bobo/code/x402/skills/`（含 `agent-wallet` / `recharge-skill`）
+- **tron-contrib** = `tron-contribution/`（合约 + 上游 PR）
+
+## 工作量按 day 估（AI 辅助节奏）
+
+数字 = 净开发天数（含测试，不含等审计 / 等部署）。范围表示不确定性。
+
+## 主线版本
+
+| 版本 | 功能 | 工作量 | 说明 | 连带改动组件 |
+|---|---|---|---|---|
+| **v0.6.0** | TS 补全 Py parity | **7-10d** | TS 端补齐：facilitator 客户端 + facilitator 服务端 + Hono / Express 中间件 + Fetch wrapper。上游 TS v1.2.0 有现成参考可直接端口 | TS SDK；demo |
+| **v0.6.1** | Extension 框架（双端新建） | **5d** | 对齐上游 `ResourceServerExtension` 接口 + 7 个 hooks（onBeforeVerify / onAfterVerify / onVerifyFailure / onBeforeSettle / onAfterSettle / onSettleFailure / onVerifiedPaymentCanceled）+ declaration / extraction helpers。后续所有 extension 的地基 | TS SDK；Py SDK；specs；facilitator；cli；demo |
+| **v0.6.2** | Permit2 集成（TRON） | **7-10d** | 复用 SUN.io 主网部署 Permit2，新增 `exact_permit2_tron` mechanism。客户端按标准 `PermitTransferFrom` typed-data 签名（钱包能识别）。upto 的前置。含合约部署 | TS SDK；Py SDK；specs；cli；facilitator；demo；skills；tron-contrib |
+| **v0.6.3** | Permit2 集成（BSC） | **3d** | 端口 Coinbase EVM 实现（`eip155:*` 通配自动适配 BSC）。MetaMask / OKX / Trust Wallet 原生识别签名；与 Coinbase 上游 EVM 路径互通 | TS SDK；Py SDK；facilitator；demo |
+| **v0.6.4** | upto 计量计费 scheme | **7d** | 客户端签 max-authorization，服务端按实际消耗 partial-settle。LLM token / 推理时长 / 带宽计量。EVM 端可端口上游 [`coinbase-x402/python/x402/mechanisms/evm/upto/`](../coinbase-x402/python/x402/mechanisms/evm/upto/)（1400+ LoC）；TRON 端基于 v0.6.2 Permit2 自研 | TS SDK；Py SDK；specs；cli；facilitator；demo；skills；tron-contrib |
+| **v0.7.0** | 支付幂等键扩展（payment-identifier） | **3d** | 客户端在 `extensions["payment-identifier"]` 带唯一 id，服务端去重重试请求防止重复扣费。Coinbase v2 spec 标配，依赖 v0.6.1 Extension 框架 | TS SDK；Py SDK；specs；cli；facilitator；demo |
+
+## 候选（待拍）
+
+| 候选 | 功能 | 工作量 | 说明 | 连带改动组件 |
+|---|---|---|---|---|
+| **batch-settlement scheme** | 批量结算（agent 高频微支付场景） | **15-20d** | Coinbase 刚发的新 scheme（[spec](../coinbase-x402/specs/schemes/batch-settlement/scheme_batch_settlement.md) + TS SDK）。客户端先签 voucher 服务端立即放行，最后批量结算。AI agent LLM 每 token 收钱场景必备。facilitator 需要全新 commitment + async redemption 体系，工作量主要在这 | TS SDK；Py SDK；specs；facilitator；cli；demo；skills |
+| **auth-hints extension** | 在 PaymentRequired 里提示哪些 accepts 需要 auth | **3d** | 上游新 extension。比 payment-identifier 更面向 agent 工具链。Server ↔ Client 扩展，不经 facilitator | TS SDK；Py SDK；specs；cli |
+| **bazaar 服务发现 + MCP discovery** | agent 通过 MCP 自动发现并付费调用 x402 endpoint | **7-10d** | 之前砍掉了，但上游加了 MCP discovery 集成 —— 跟 `apollo-arena` / `ainft-merchant-agent` 强相关 | TS SDK；Py SDK；cli；facilitator；skills |
+
+## 工作量小计
+
+| 阶段 | 主线 | 天数 |
+|---|---|---|
+| 两端对齐基础 | v0.6.0 + v0.6.1 | 12-15d |
+| Permit2 双链 | v0.6.2 + v0.6.3 | 10-13d |
+| 协议新能力 | v0.6.4 + v0.7.0 | 10d |
+| **主线总计** | 6 个版本 | **32-38d** |
+
+候选全做再加 25-33d。最关键的工作量黑洞是 **v0.6.0**（5 个补齐项打包）和 **batch-settlement**（facilitator 大改）。
+
+## Permit2 背景说明（v0.6.2 + v0.6.3）
+
+**当前 `exact_permit` 用的是我们自有的 `PaymentPermit` 合约**（TRON mainnet `TT8rEWbCoNX7vpEUauxb7rWJsTgs8vDLAn`、BSC `0x1825bB32db3443dEc2cc7508b2D818fc13EaD878`），自定义 EIP-712 type。**不是** EIP-2612 token 原生 permit，**也不是** Uniswap Permit2。
+
+**硬伤：** 用户每个新协议都要重新 `approve(我们的合约)` / 钱包不识别签名 / 跟 Coinbase 上游不互通 / `PaymentPermit` 合约没 partial-settle 接口（upto 没法做）。
+
+**Uniswap Permit2** 是行业标准的通用 ERC-20 授权层：用户 `approve(Permit2, max)` 一次，所有接 Permit2 协议（Uniswap、1inch、Across、Coinbase x402 EVM、各类 agent SDK）共用。已部署在所有主流 EVM 链 + **TRON 主网（SUN.io 部署）+ BSC**。
+
+**两套并存，不替换：**
+
+```
+token 支持 ERC-3009 → exact             （直接 transferWithAuthorization）
+token 支持 EIP-2612 → exact_permit      （我们的 PaymentPermit，现状）
+否则                → exact_permit2     （兜底，新加；upto 也走这条路）
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@
 
 | 版本 | 功能 | 工作量 | 说明 | 连带改动组件 |
 |---|---|---|---|---|
-| **v0.6.0** | TS 补全 Py parity | **7-10d** | TS 端补齐：facilitator 客户端 + facilitator 服务端 + Hono / Express 中间件 + Fetch wrapper。上游 TS v1.2.0 有现成参考可直接端口 | TS SDK；demo |
+| **v0.6.0** | TS 补全 Py parity | **完成，准备发布** | TS 端已补齐：facilitator 客户端 + facilitator 服务端 + Hono / Express 中间件 + Fetch wrapper + signer-injected facilitator verify/settle（`exact` / `exact_permit` / `exact_gasfree`）。x402-demo 已用 0.6.0 beta 线完成 TypeScript QA smoke 和 TRON Nile 上链验证 | TS SDK；demo |
 | **v0.6.1** | Extension 框架（双端新建） | **5d** | 对齐上游 `ResourceServerExtension` 接口 + 7 个 hooks（onBeforeVerify / onAfterVerify / onVerifyFailure / onBeforeSettle / onAfterSettle / onSettleFailure / onVerifiedPaymentCanceled）+ declaration / extraction helpers。后续所有 extension 的地基 | TS SDK；Py SDK；specs；facilitator；cli；demo |
 | **v0.6.2** | Permit2 集成（TRON） | **7-10d** | 复用 SUN.io 主网部署 Permit2，新增 `exact_permit2_tron` mechanism。客户端按标准 `PermitTransferFrom` typed-data 签名（钱包能识别）。upto 的前置。含合约部署 | TS SDK；Py SDK；specs；cli；facilitator；demo；skills；tron-contrib |
 | **v0.6.3** | Permit2 集成（BSC） | **3d** | 端口 Coinbase EVM 实现（`eip155:*` 通配自动适配 BSC）。MetaMask / OKX / Trust Wallet 原生识别签名；与 Coinbase 上游 EVM 路径互通 | TS SDK；Py SDK；facilitator；demo |
@@ -43,7 +43,7 @@
 | 协议新能力 | v0.6.4 + v0.7.0 | 10d |
 | **主线总计** | 6 个版本 | **32-38d** |
 
-候选全做再加 25-33d。最关键的工作量黑洞是 **v0.6.0**（5 个补齐项打包）和 **batch-settlement**（facilitator 大改）。
+候选全做再加 25-33d。当前最大的工作量黑洞转到 **batch-settlement**（facilitator 大改）；**v0.6.0** 已完成并进入正式发布准备。
 
 ## Permit2 背景说明（v0.6.2 + v0.6.3）
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@
 
 | 版本 | 功能 | 工作量 | 说明 | 连带改动组件 |
 |---|---|---|---|---|
-| **v0.6.0** | TS 补全 Py parity | **完成，准备发布** | TS 端已补齐：facilitator 客户端 + facilitator 服务端 + Hono / Express 中间件 + Fetch wrapper + signer-injected facilitator verify/settle（`exact` / `exact_permit` / `exact_gasfree`）。x402-demo 已用 0.6.0 beta 线完成 TypeScript QA smoke 和 TRON Nile 上链验证 | TS SDK；demo |
+| **v0.6.0** | TS 补全 Py parity | **完成，可发布** | TS 端已补齐：facilitator 客户端 + facilitator 服务端 + Hono / Express 中间件 + Fetch wrapper + signer-injected facilitator verify/settle（`exact` / `exact_permit` / `exact_gasfree`）。x402-demo 已完成 TypeScript QA smoke 和 TRON Nile 上链验证 | TS SDK；demo |
 | **v0.6.1** | Extension 框架（双端新建） | **5d** | 对齐上游 `ResourceServerExtension` 接口 + 7 个 hooks（onBeforeVerify / onAfterVerify / onVerifyFailure / onBeforeSettle / onAfterSettle / onSettleFailure / onVerifiedPaymentCanceled）+ declaration / extraction helpers。后续所有 extension 的地基 | TS SDK；Py SDK；specs；facilitator；cli；demo |
 | **v0.6.2** | Permit2 集成（TRON） | **7-10d** | 复用 SUN.io 主网部署 Permit2，新增 `exact_permit2_tron` mechanism。客户端按标准 `PermitTransferFrom` typed-data 签名（钱包能识别）。upto 的前置。含合约部署 | TS SDK；Py SDK；specs；cli；facilitator；demo；skills；tron-contrib |
 | **v0.6.3** | Permit2 集成（BSC） | **3d** | 端口 Coinbase EVM 实现（`eip155:*` 通配自动适配 BSC）。MetaMask / OKX / Trust Wallet 原生识别签名；与 Coinbase 上游 EVM 路径互通 | TS SDK；Py SDK；facilitator；demo |
@@ -43,7 +43,7 @@
 | 协议新能力 | v0.6.4 + v0.7.0 | 10d |
 | **主线总计** | 6 个版本 | **32-38d** |
 
-候选全做再加 25-33d。当前最大的工作量黑洞转到 **batch-settlement**（facilitator 大改）；**v0.6.0** 已完成并进入正式发布准备。
+候选全做再加 25-33d。当前最大的工作量黑洞转到 **batch-settlement**（facilitator 大改）；**v0.6.0** 已完成并可正式发布。
 
 ## Permit2 背景说明（v0.6.2 + v0.6.3）
 

--- a/python/x402/README.md
+++ b/python/x402/README.md
@@ -2,6 +2,8 @@
 
 Python SDK for the x402 payment protocol — supports TRON and EVM (BSC) networks.
 
+Current release: `bankofai-x402==0.6.0`. This release is aligned with the TypeScript SDK for client, server, and facilitator `exact`, `exact_permit`, and `exact_gasfree` flows.
+
 ## Compatibility Notes
 
 - The EVM `exact` flow is being aligned to the Coinbase x402 v2 payload shape.
@@ -11,7 +13,7 @@ Python SDK for the x402 payment protocol — supports TRON and EVM (BSC) network
 ## Installation
 
 ```bash
-pip install bankofai-x402
+pip install bankofai-x402==0.6.0
 ```
 
 Optional extras:

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.6.0b0"
+version = "0.6.0"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.5.9"
+version = "0.6.0b0"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py
+++ b/python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py
@@ -48,12 +48,12 @@ class TronFacilitatorSigner(FacilitatorSigner):
         # Resolve private key for direct tronpy signing (bypasses agent-wallet
         # sign_transaction which requires raw_data_hex that tronpy does not expose).
         # Priority: TRON_FACILITATOR_PRIVATE_KEY env → TRON_PRIVATE_KEY env
-        raw_pk = (
-            os.environ.get("TRON_FACILITATOR_PRIVATE_KEY")
-            or os.environ.get("TRON_PRIVATE_KEY")
+        raw_pk = os.environ.get("TRON_FACILITATOR_PRIVATE_KEY") or os.environ.get(
+            "TRON_PRIVATE_KEY"
         )
         if raw_pk:
             from tronpy.keys import PrivateKey as TronPrivateKey
+
             signer._private_key = TronPrivateKey(bytes.fromhex(raw_pk))
         return signer
 
@@ -300,8 +300,7 @@ class TronFacilitatorSigner(FacilitatorSigner):
             # AsyncTron: func(*args) returns a coroutine, need to await it first
             txn_builder = await func(*args)
             txn_builder = (
-                txn_builder
-                .with_owner(address)
+                txn_builder.with_owner(address)
                 .permission_id(self._permission_id)  # use active permission (id=2) by default
                 .fee_limit(1_000_000_000)
             )

--- a/python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py
+++ b/python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py
@@ -8,6 +8,7 @@ The signer is agnostic about how the wallet was created (private key, hosted, et
 
 import asyncio
 import json as json_module
+import os
 import time
 from typing import Any
 
@@ -29,6 +30,10 @@ class TronFacilitatorSigner(FacilitatorSigner):
         self._wallet = wallet
         self._address: str | None = None
         self._async_tron_clients: dict[str, Any] = {}
+        self._private_key: Any = None  # tronpy PrivateKey for direct signing
+        # TRON_PERMISSION_ID: 0=owner, 2=active (default). Multi-sig accounts
+        # with owner threshold > 1 must use permission_id=2 (active).
+        self._permission_id: int = int(os.environ.get("TRON_PERMISSION_ID", "2"))
 
     @classmethod
     async def create(cls) -> "TronFacilitatorSigner":
@@ -39,6 +44,17 @@ class TronFacilitatorSigner(FacilitatorSigner):
         wallet = await provider.get_active_wallet()
         signer = cls(wallet)
         signer.set_address(await wallet.get_address())
+
+        # Resolve private key for direct tronpy signing (bypasses agent-wallet
+        # sign_transaction which requires raw_data_hex that tronpy does not expose).
+        # Priority: TRON_FACILITATOR_PRIVATE_KEY env → TRON_PRIVATE_KEY env
+        raw_pk = (
+            os.environ.get("TRON_FACILITATOR_PRIVATE_KEY")
+            or os.environ.get("TRON_PRIVATE_KEY")
+        )
+        if raw_pk:
+            from tronpy.keys import PrivateKey as TronPrivateKey
+            signer._private_key = TronPrivateKey(bytes.fromhex(raw_pk))
         return signer
 
     @staticmethod
@@ -283,14 +299,22 @@ class TronFacilitatorSigner(FacilitatorSigner):
             logger.info("Building transaction with fee_limit=1,000,000,000 SUN (1000 TRX)")
             # AsyncTron: func(*args) returns a coroutine, need to await it first
             txn_builder = await func(*args)
-            txn_builder = txn_builder.with_owner(address).fee_limit(1_000_000_000)
+            txn_builder = (
+                txn_builder
+                .with_owner(address)
+                .permission_id(self._permission_id)  # use active permission (id=2) by default
+                .fee_limit(1_000_000_000)
+            )
             txn = await txn_builder.build()
-            # Sign the transaction via wallet
-            unsigned_payload = _build_unsigned_tx_payload(txn)
-            raw_result = await self._wallet.sign_transaction(unsigned_payload)
-            sig_hex = self._extract_tron_signature(raw_result)
 
-            txn._signature = [sig_hex]
+            # Sign directly with tronpy private key (agent-wallet sign_transaction
+            # requires raw_data_hex which tronpy does not expose in to_json()).
+            if self._private_key is None:
+                raise RuntimeError(
+                    "TronFacilitatorSigner: private key not available for signing. "
+                    "Set TRON_FACILITATOR_PRIVATE_KEY or TRON_PRIVATE_KEY in environment."
+                )
+            txn = txn.sign(self._private_key)
 
             # Log transaction details before broadcast
             try:

--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -83,6 +83,10 @@ class GasFreeAPIClient:
         try:
             headers = self._get_headers()
             response = await self._client.get(url, headers=headers)
+            if response.status_code == 404:
+                # Network not supported by GasFree service — return empty list gracefully
+                logger.warning(f"GasFree service not available for this network (404): {url}")
+                return []
             if response.status_code != 200:
                 logger.error(f"GasFree API error {response.status_code}: {response.text}")
                 response.raise_for_status()
@@ -98,6 +102,7 @@ class GasFreeAPIClient:
         except Exception as e:
             logger.error(f"Failed to get providers from GasFree API: {e}")
             raise
+
 
     async def get_nonce(self, user: str, token: str, chain_id: int) -> int:
         """Get current recommended nonce for a user"""

--- a/python/x402/src/bankofai/x402/utils/gasfree.py
+++ b/python/x402/src/bankofai/x402/utils/gasfree.py
@@ -103,7 +103,6 @@ class GasFreeAPIClient:
             logger.error(f"Failed to get providers from GasFree API: {e}")
             raise
 
-
     async def get_nonce(self, user: str, token: str, chain_id: int) -> int:
         """Get current recommended nonce for a user"""
         try:

--- a/python/x402/src/bankofai/x402/utils/tron_client.py
+++ b/python/x402/src/bankofai/x402/utils/tron_client.py
@@ -15,6 +15,8 @@ from tronpy.providers.async_http import AsyncHTTPProvider
 logger = logging.getLogger(__name__)
 
 TRON_MAINNET_FALLBACK_URL = "https://hptg.bankofai.io"
+TRON_NILE_FALLBACK_URL = "https://api.nileex.io"
+TRON_SHASTA_FALLBACK_URL = "https://api.shasta.trongrid.io"
 
 
 def create_async_tron_client(network: str) -> Any:
@@ -48,6 +50,24 @@ def create_async_tron_client(network: str) -> Any:
                 "Creating AsyncTron client with fallback provider for network=%s (%s)",
                 network,
                 TRON_MAINNET_FALLBACK_URL,
+            )
+            return AsyncTron(provider=provider, network=network)
+
+        if network == "nile":
+            provider = AsyncHTTPProvider(endpoint_uri=TRON_NILE_FALLBACK_URL)
+            logger.info(
+                "Creating AsyncTron client with fallback provider for network=%s (%s)",
+                network,
+                TRON_NILE_FALLBACK_URL,
+            )
+            return AsyncTron(provider=provider, network=network)
+
+        if network == "shasta":
+            provider = AsyncHTTPProvider(endpoint_uri=TRON_SHASTA_FALLBACK_URL)
+            logger.info(
+                "Creating AsyncTron client with fallback provider for network=%s (%s)",
+                network,
+                TRON_SHASTA_FALLBACK_URL,
             )
             return AsyncTron(provider=provider, network=network)
 

--- a/python/x402/tests/utils/test_tron_client_factory.py
+++ b/python/x402/tests/utils/test_tron_client_factory.py
@@ -43,12 +43,19 @@ class TestCreateAsyncTronClientFallback:
         mock_tron_cls.assert_called_once_with(provider=mock_provider, network="mainnet")
 
     @patch("bankofai.x402.utils.tron_client.AsyncTron")
+    @patch("bankofai.x402.utils.tron_client.AsyncHTTPProvider")
     @patch.dict("os.environ", {}, clear=True)
-    def test_nile_uses_default_without_api_key(self, mock_tron_cls):
-        """Non-mainnet networks should use tronpy defaults when API key is not set."""
+    def test_nile_uses_default_without_api_key(self, mock_provider_cls, mock_tron_cls):
+        """Non-mainnet networks use the nile fallback RPC URL when API key is not set."""
+        from bankofai.x402.utils.tron_client import TRON_NILE_FALLBACK_URL
+
+        mock_provider = MagicMock()
+        mock_provider_cls.return_value = mock_provider
+
         create_async_tron_client("nile")
 
-        mock_tron_cls.assert_called_once_with(network="nile")
+        mock_provider_cls.assert_called_once_with(endpoint_uri=TRON_NILE_FALLBACK_URL)
+        mock_tron_cls.assert_called_once_with(provider=mock_provider, network="nile")
 
     @patch("bankofai.x402.utils.tron_client.AsyncTron")
     @patch("bankofai.x402.utils.tron_client.AsyncHTTPProvider")

--- a/python/x402/uv.lock
+++ b/python/x402/uv.lock
@@ -200,7 +200,7 @@ wheels = [
 
 [[package]]
 name = "bankofai-x402"
-version = "0.5.8"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "bankofai-agent-wallet" },

--- a/specs/CLAUDE.md
+++ b/specs/CLAUDE.md
@@ -13,6 +13,8 @@ specs/
 │   ├── exact.md             — ERC-3009 transferWithAuthorization
 │   ├── exact-permit.md      — EIP-2612 / TIP-2612 permit + transferFrom
 │   └── exact-gasfree.md     — TRON GasFree custodial + TIP-712 relayer
+├── transports/
+│   └── facilitator-http.md  — server ↔ facilitator REST API (verify / settle / supported / fee/quote)
 └── <NNN>-<slug>/            — in-flight feature spec (spec-kit template)
     ├── spec.md              — requirements, acceptance criteria, open questions
     ├── plan.md              — implementation plan (if present)

--- a/specs/transports/facilitator-http.md
+++ b/specs/transports/facilitator-http.md
@@ -1,0 +1,260 @@
+# Transport: Facilitator HTTP API
+
+> Spec for the **server ↔ facilitator** transport. Distinct from the **client ↔ server** HTTP transport defined elsewhere — that one is governed by the x402 protocol headers (`PAYMENT-REQUIRED` / `PAYMENT-SIGNATURE` / `PAYMENT-RESPONSE`) and HTTP 402; this one is the ordinary REST API a server uses to delegate verify / settle / fee-quote / supported queries to a facilitator.
+
+## Summary
+
+A facilitator exposes four HTTP endpoints. Clients of these endpoints are **resource servers** (running our middleware or equivalent), not end users.
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/verify` | POST | Off-chain signature / replay / timing validation |
+| `/settle` | POST | On-chain settlement (broadcast transaction) |
+| `/supported` | GET | List supported `(x402Version, scheme, network)` tuples |
+| `/fee/quote` | POST | Quote facilitator fee per requirement (optional, scheme-dependent) |
+
+All endpoints accept and return JSON. Authorization is implementation-defined; both the BankofAI Python client and the TS client forward a configurable `headers` map (typically `Authorization: Bearer …`).
+
+This spec is **descriptive of current implementation**. Any divergence from x402 Foundation upstream is flagged inline under "Upstream alignment notes" so future patches can converge.
+
+---
+
+## 1. POST /verify
+
+### Request
+
+```json
+{
+  "paymentPayload": { /* PaymentPayload */ },
+  "paymentRequirements": { /* PaymentRequirements */ }
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `paymentPayload` | `PaymentPayload` | yes | The signed payload submitted by the client. See `specs/protocol.md`. |
+| `paymentRequirements` | `PaymentRequirements` | yes | The requirement entry from `accepts[]` that the client elected to pay. |
+
+### Response — success
+
+```json
+{ "isValid": true }
+```
+
+### Response — failure
+
+```json
+{
+  "isValid": false,
+  "invalidReason": "string"
+}
+```
+
+`invalidReason` is a free-form human-readable string. Common values include:
+
+- `"unsupported_network_scheme: <network>/<scheme>"` — facilitator does not have a registered mechanism for this pair
+- `"Invalid EVM address for <field>: <value>"` — checksum validation failed
+- mechanism-specific reasons (e.g. `"signature mismatch"`, `"validBefore expired"`, `"nonce already used"`)
+
+### Status codes
+
+| Code | Meaning |
+|---|---|
+| 200 | Verification ran (regardless of `isValid` outcome) |
+| 4xx / 5xx | Transport / facilitator infrastructure error |
+
+The `isValid: false` path is **not** a 4xx — verification ran successfully, the result was negative.
+
+### Upstream alignment notes
+
+- Upstream `x402-specification-v2.md` §7.1 **wraps** the body with a top-level `x402Version: 2` field. **Our current implementation omits this field.** Both directions are tolerant of the omission today; alignment is tracked in roadmap.
+- Upstream successful response includes `payer: "0x…"`. Ours does not currently emit `payer`.
+
+---
+
+## 2. POST /settle
+
+### Request
+
+Identical to `/verify`:
+
+```json
+{
+  "paymentPayload": { /* PaymentPayload */ },
+  "paymentRequirements": { /* PaymentRequirements */ }
+}
+```
+
+### Response — success
+
+```json
+{
+  "success": true,
+  "transaction": "0x…",
+  "network": "tron:nile"
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `success` | `boolean` | yes | `true` on settlement |
+| `transaction` | `string` | yes (on success) | Transaction hash. EVM = 0x-prefixed hex; TRON = 64-hex (no prefix). |
+| `network` | `string` | yes | CAIP-2 identifier (`tron:<name>` or `eip155:<chainId>`) |
+
+### Response — failure
+
+```json
+{
+  "success": false,
+  "errorReason": "string",
+  "network": "tron:nile",
+  "transaction": "0x…"
+}
+```
+
+`transaction` is optional on failure (e.g. the tx was broadcast but reverted on-chain — the hash is still useful for diagnosis).
+
+### Status codes
+
+Same as `/verify`. Mechanism failures surface as `success: false` + `errorReason`, not 4xx / 5xx.
+
+### Upstream alignment notes
+
+- Upstream §7.2 includes `payer` on both success and failure responses. Ours does not.
+
+---
+
+## 3. GET /supported
+
+Used by clients to discover what the facilitator can handle before posting a verify/settle.
+
+### Response
+
+```json
+{
+  "kinds": [
+    { "x402Version": 2, "scheme": "exact", "network": "tron:mainnet" },
+    { "x402Version": 2, "scheme": "exact_permit", "network": "tron:mainnet" },
+    { "x402Version": 2, "scheme": "exact_gasfree", "network": "tron:nile" },
+    { "x402Version": 2, "scheme": "exact_permit", "network": "eip155:97" }
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `kinds` | array | yes | One entry per registered `(x402Version, scheme, network)` |
+| `kinds[].x402Version` | number | yes | Always `2` in current code |
+| `kinds[].scheme` | string | yes | Scheme identifier (`exact`, `exact_permit`, `exact_gasfree`, ...) |
+| `kinds[].network` | string | yes | CAIP-2 identifier |
+
+### Upstream alignment notes
+
+- Upstream §7.3 adds two top-level fields:
+  - `extensions`: array of supported extension keys (e.g. `["payment-identifier", "auth-hints"]`).
+  - `signers`: map `{ "<caip-pattern>": ["0x…"] }` advertising the facilitator's signing addresses.
+- Both are absent from our current response. Adding them is queued under v0.6.1 (extension framework) — `extensions` will be derivable from registered extensions; `signers` is a config addition.
+
+---
+
+## 4. POST /fee/quote
+
+Optional endpoint. Returns per-requirement fee quotes. Schemes that don't charge a facilitator fee may return an empty array.
+
+### Request
+
+```json
+{
+  "accepts": [ /* PaymentRequirements[] */ ],
+  "paymentPermitContext": { /* optional, scheme-defined */ }
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `accepts` | array | yes | One or more `PaymentRequirements`. Same shape as the `accepts` field in `PaymentRequired`. |
+| `paymentPermitContext` | object | no | Forwarded as-is to the mechanism. Used by `exact_permit` to pass `paymentId` / `nonce` / validity window. |
+
+### Response
+
+```json
+[
+  {
+    "fee": { "feeTo": "T…", "feeAmount": "100000", "facilitatorId": "…", "caller": "T…" },
+    "pricing": "fixed",
+    "scheme": "exact_permit",
+    "network": "tron:mainnet",
+    "asset": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+    "expiresAt": 1751234567
+  }
+]
+```
+
+The result array length **may be shorter than the input `accepts.length`** — entries the facilitator cannot quote (unsupported `(network, scheme)`, or mechanism returned `null`) are silently dropped.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `fee` | object | yes | Fee structure. `feeTo` = recipient address; `feeAmount` = smallest-unit string. `facilitatorId` is set when the facilitator wants the on-chain proxy to bind a specific signer. `caller` for schemes (e.g. `exact_permit`) where the on-chain caller must equal a specific address. |
+| `pricing` | string | yes | Mechanism-defined pricing model identifier. `"fixed"` for a flat fee; mechanisms may add others. |
+| `scheme` / `network` / `asset` | string | yes | Echo of the input requirement so the caller can correlate quotes back to entries. |
+| `expiresAt` | number | no | Unix seconds after which this quote is no longer authoritative. |
+
+### Upstream alignment notes
+
+- Upstream v2 spec does not currently standardize a `/fee/quote` endpoint at the same level. Our endpoint is BankofAI-specific, motivated by `exact_permit` / `exact_gasfree` needing a facilitator fee inserted into payment requirements before signing.
+
+---
+
+## 5. Authorization
+
+Authentication is implementation-defined. Recommended pattern: HTTP `Authorization: Bearer <token>` with per-tenant tokens. Both reference clients (`bankofai.x402.facilitator.FacilitatorClient` Python; `FacilitatorClient` TypeScript) accept a `headers` map at construction:
+
+```python
+FacilitatorClient(base_url="https://fac.example", headers={"Authorization": "Bearer abc"})
+```
+
+```ts
+new FacilitatorClient({ baseUrl: 'https://fac.example', headers: { Authorization: 'Bearer abc' } })
+```
+
+The headers are forwarded verbatim on every request.
+
+## 6. Timeouts and cancellation
+
+- Default per-request timeout: **120 seconds** in both reference clients. `/settle` may take a non-trivial fraction of this on busy networks.
+- Cancellation: TS client uses `AbortController`; Python client uses `httpx`'s timeout. Both surface a transport-level error to the caller — the facilitator does NOT receive a "settle was cancelled" notification.
+
+## 7. Error handling
+
+All transport / facilitator-side failures (non-2xx, malformed JSON, network failure) are raised to the caller as a typed exception:
+
+| Runtime | Exception |
+|---|---|
+| Python | `httpx.HTTPStatusError` (from `response.raise_for_status()`) for non-2xx |
+| TypeScript | `FacilitatorError` (this repo, in `src/errors.ts`) — carries `status` and `body` |
+
+Mechanism-level failures (signature invalid, insufficient balance, etc.) are returned **inside** a 200 response as `isValid: false` / `success: false`. They are not transport errors.
+
+---
+
+## 8. Reference implementations
+
+| Runtime | File |
+|---|---|
+| Python client | `python/x402/src/bankofai/x402/facilitator/facilitator_client.py` |
+| Python server engine | `python/x402/src/bankofai/x402/facilitator/x402_facilitator.py` |
+| Python server example | `examples/facilitator/server.py` |
+| TypeScript client | `typescript/packages/x402/src/facilitator/client.ts` |
+| TypeScript server engine | `typescript/packages/x402/src/facilitator/x402Facilitator.ts` |
+
+The Python and TypeScript clients are byte-compatible against the same facilitator service. Tests in `python/x402/tests/facilitator/` and `typescript/packages/x402/src/facilitator/*.test.ts` cover the wire shapes documented here.
+
+## 9. Versioning
+
+This transport spec is implicitly tied to **x402 protocol v2**. A future protocol version that changes the wire shape MAY be carried over the same endpoint paths with a new top-level `x402Version` field discriminating the body shape.
+
+---
+
+## Change log
+
+- **2026-05** — Initial draft. Captures current behaviour as of v0.6.0.

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -5143,7 +5143,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.6.0",
+      "version": "0.6.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -5143,7 +5143,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.6.0-beta.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -5143,7 +5143,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -15,8 +15,8 @@
         "typescript": "^5.3.0"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "pnpm": ">=8.0.0"
+        "node": ">=20.0.0",
+        "pnpm": ">=10.0.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -1531,10 +1531,63 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1556,12 +1609,47 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/secp256k1": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.7.tgz",
       "integrity": "sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==",
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
         "@types/node": "*"
       }
     },
@@ -1658,6 +1746,47 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
@@ -1800,6 +1929,31 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -1868,6 +2022,16 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -2006,6 +2170,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-js-pure": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
@@ -2122,6 +2330,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2146,6 +2364,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/elliptic": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
@@ -2159,6 +2384,16 @@
         "inherits": "^2.0.4",
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/es-define-property": {
@@ -2245,6 +2480,13 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2253,6 +2495,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/eth-sig-util": {
@@ -2547,6 +2799,77 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -2569,6 +2892,28 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/follow-redirects": {
@@ -2620,6 +2965,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -2811,6 +3176,37 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2863,6 +3259,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2884,6 +3290,13 @@
         "node": ">=6.5.0",
         "npm": ">=3"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -3043,6 +3456,29 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3151,6 +3587,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
@@ -3195,6 +3641,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3328,6 +3810,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3336,6 +3828,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3457,11 +3960,41 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -3470,6 +4003,32 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -3582,6 +4141,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3647,6 +4223,80 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -3669,6 +4319,13 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -3713,6 +4370,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3748,6 +4481,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -3857,6 +4600,16 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tronweb": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.2.0.tgz",
@@ -3903,6 +4656,48 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -3944,6 +4739,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3957,6 +4762,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/viem": {
@@ -4276,6 +5091,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
@@ -4321,7 +5143,7 @@
     },
     "packages/x402": {
       "name": "@bankofai/x402",
-      "version": "0.5.9",
+      "version": "0.6.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@bankofai/agent-wallet": "^2.3.0",
@@ -4329,15 +5151,28 @@
         "viem": "^2.45.2"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^20.10.0",
+        "express": "^5.2.1",
+        "hono": "^4.12.18",
         "typescript": "^5.3.0",
         "vitest": "^1.6.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0",
+        "hono": "^4.0.0",
         "tronweb": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        }
       }
     }
   }

--- a/typescript/packages/x402/README.md
+++ b/typescript/packages/x402/README.md
@@ -2,6 +2,8 @@
 
 TypeScript SDK for the x402 payment protocol. Supports TRON and EVM (BSC) networks with automatic HTTP 402 payment handling.
 
+Current release: `@bankofai/x402@0.6.0`. This release includes TypeScript client, server, and facilitator parity with the Python SDK for `exact`, `exact_permit`, and `exact_gasfree` verify/settle flows.
+
 ## Compatibility Notes
 
 - The EVM `exact` flow is being aligned to the Coinbase x402 v2 payload shape.
@@ -20,7 +22,7 @@ TypeScript SDK for the x402 payment protocol. Supports TRON and EVM (BSC) networ
 ## Installation
 
 ```bash
-npm i @bankofai/x402 tronweb
+npm i @bankofai/x402@0.6.0 tronweb
 ```
 
 ## Quick Start

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.5.9",
+  "version": "0.6.0-beta.0",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",
@@ -53,8 +53,12 @@
     "express": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
-    "hono": { "optional": true },
-    "express": { "optional": true }
+    "hono": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.6.0",
+  "version": "0.6.0-beta.2",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -48,10 +48,19 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "tronweb": "^5.0.0 || ^6.0.0"
+    "tronweb": "^5.0.0 || ^6.0.0",
+    "hono": "^4.0.0",
+    "express": "^4.0.0 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "hono": { "optional": true },
+    "express": { "optional": true }
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^20.10.0",
+    "express": "^5.2.1",
+    "hono": "^4.12.18",
     "typescript": "^5.3.0",
     "vitest": "^1.6.1"
   },

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.6.0-beta.0",
+  "version": "0.6.0-beta.1",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",

--- a/typescript/packages/x402/src/abi.ts
+++ b/typescript/packages/x402/src/abi.ts
@@ -87,4 +87,121 @@ export const ERC20_ABI = [
     ],
     outputs: [{ name: '', type: 'bool' }],
   },
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
+/**
+ * PaymentPermit contract ABI (subset used by facilitator settlement).
+ *
+ * Mirrors Python `bankofai.x402.abi.PAYMENT_PERMIT_ABI`. Only the methods
+ * actually called by the facilitator are included; the on-chain contract
+ * exposes more (DOMAIN_SEPARATOR, nonceBitmap, nonceUsed) that we surface
+ * here in case TS callers need them too.
+ */
+export const PAYMENT_PERMIT_ABI = [
+  {
+    name: 'permitTransferFrom',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'permit',
+        type: 'tuple',
+        components: [
+          {
+            name: 'meta',
+            type: 'tuple',
+            components: [
+              { name: 'kind', type: 'uint8' },
+              { name: 'paymentId', type: 'bytes16' },
+              { name: 'nonce', type: 'uint256' },
+              { name: 'validAfter', type: 'uint256' },
+              { name: 'validBefore', type: 'uint256' },
+            ],
+          },
+          { name: 'buyer', type: 'address' },
+          { name: 'caller', type: 'address' },
+          {
+            name: 'payment',
+            type: 'tuple',
+            components: [
+              { name: 'payToken', type: 'address' },
+              { name: 'payAmount', type: 'uint256' },
+              { name: 'payTo', type: 'address' },
+            ],
+          },
+          {
+            name: 'fee',
+            type: 'tuple',
+            components: [
+              { name: 'feeTo', type: 'address' },
+              { name: 'feeAmount', type: 'uint256' },
+            ],
+          },
+        ],
+      },
+      { name: 'owner', type: 'address' },
+      { name: 'signature', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'DOMAIN_SEPARATOR',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32' }],
+  },
+  {
+    name: 'nonceUsed',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'owner', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+] as const;
+
+/**
+ * ERC-3009 `transferWithAuthorization` ABI (v, r, s variant).
+ *
+ * Mirrors Python `bankofai.x402.mechanisms._exact_base.types.TRANSFER_WITH_AUTHORIZATION_ABI`.
+ * Used by `exact` scheme facilitator settle.
+ */
+export const TRANSFER_WITH_AUTHORIZATION_ABI = [
+  {
+    name: 'transferWithAuthorization',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'validAfter', type: 'uint256' },
+      { name: 'validBefore', type: 'uint256' },
+      { name: 'nonce', type: 'bytes32' },
+      { name: 'v', type: 'uint8' },
+      { name: 'r', type: 'bytes32' },
+      { name: 's', type: 'bytes32' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'authorizationState',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'authorizer', type: 'address' },
+      { name: 'nonce', type: 'bytes32' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
 ] as const;

--- a/typescript/packages/x402/src/client/x402Client.ts
+++ b/typescript/packages/x402/src/client/x402Client.ts
@@ -4,7 +4,7 @@
  * Manages payment mechanism registry and coordinates payment flows.
  */
 
-import { ExactGasFreeClientMechanism } from '../mechanisms/exactGasfree.js';
+import { ExactGasFreeClientMechanism } from '../mechanisms/tron/exact_gasfree/index.js';
 import { GasFreeAPIClient } from '../utils/gasfree.js';
 import type {
   PaymentRequirements,

--- a/typescript/packages/x402/src/errors.ts
+++ b/typescript/packages/x402/src/errors.ts
@@ -76,3 +76,18 @@ export class PermitValidationError extends ValidationError {
     this.reason = reason;
   }
 }
+
+/** Facilitator HTTP / protocol error */
+export class FacilitatorError extends X402Error {
+  /** HTTP status code returned by facilitator (0 if request itself failed) */
+  status: number;
+  /** Response body, decoded as text or null if unavailable */
+  body: string | null;
+
+  constructor(message: string, status: number, body: string | null = null) {
+    super(message);
+    this.name = 'FacilitatorError';
+    this.status = status;
+    this.body = body;
+  }
+}

--- a/typescript/packages/x402/src/facilitator/client.test.ts
+++ b/typescript/packages/x402/src/facilitator/client.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for FacilitatorClient.
+ *
+ * Uses a fake fetch impl so the suite stays hermetic — no live HTTP, no servers.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { FacilitatorError } from '../errors.js';
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  SupportedResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import { FacilitatorClient } from './client.js';
+
+/** Build a fake fetch that returns a single canned response and records the call. */
+function mockFetch(json: unknown, status = 200): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; init: RequestInit | undefined }>;
+} {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  const fetchImpl: typeof fetch = vi.fn(async (input, init) => {
+    calls.push({
+      url: typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url,
+      init,
+    });
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const REQUIREMENTS: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'tron:nile',
+  maxAmountRequired: '1000000',
+  resource: 'http://example.com/api',
+  description: 'test',
+  mimeType: 'application/json',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+  maxTimeoutSeconds: 60,
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  amount: '1000000',
+};
+
+const PAYLOAD: PaymentPayload = {
+  x402Version: 2,
+  accepted: REQUIREMENTS,
+  payload: { signature: '0x' + 'aa'.repeat(65) },
+};
+
+describe('FacilitatorClient', () => {
+  it('strips trailing slashes from baseUrl', () => {
+    const client = new FacilitatorClient({
+      baseUrl: 'https://facilitator.example/',
+      fetchImpl: mockFetch({}).fetchImpl,
+    });
+    expect(client.facilitatorId).toBe('https://facilitator.example');
+  });
+
+  it('uses explicit facilitatorId when provided', () => {
+    const client = new FacilitatorClient({
+      baseUrl: 'https://facilitator.example',
+      facilitatorId: 'fac-1',
+      fetchImpl: mockFetch({}).fetchImpl,
+    });
+    expect(client.facilitatorId).toBe('fac-1');
+  });
+
+  it('GETs /supported and parses the response', async () => {
+    const supported: SupportedResponse = {
+      kinds: [{ x402Version: 2, scheme: 'exact', network: 'tron:nile' }],
+    };
+    const { fetchImpl, calls } = mockFetch(supported);
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    const result = await client.supported();
+
+    expect(result).toEqual(supported);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://fac.example/supported');
+    expect(calls[0]!.init?.method).toBe('GET');
+  });
+
+  it('POSTs /verify with snake_camelCase payload + requirements wire fields', async () => {
+    const verify: VerifyResponse = { isValid: true };
+    const { fetchImpl, calls } = mockFetch(verify);
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    const result = await client.verify(PAYLOAD, REQUIREMENTS);
+
+    expect(result).toEqual(verify);
+    expect(calls[0]!.url).toBe('https://fac.example/verify');
+    const body = JSON.parse(calls[0]!.init?.body as string);
+    expect(body.paymentPayload).toEqual(PAYLOAD);
+    expect(body.paymentRequirements).toEqual(REQUIREMENTS);
+  });
+
+  it('POSTs /settle with the same wire shape', async () => {
+    const settle: SettleResponse = {
+      success: true,
+      transaction: '0xdeadbeef',
+      network: 'tron:nile',
+    };
+    const { fetchImpl, calls } = mockFetch(settle);
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    const result = await client.settle(PAYLOAD, REQUIREMENTS);
+
+    expect(result).toEqual(settle);
+    expect(calls[0]!.url).toBe('https://fac.example/settle');
+  });
+
+  it('POSTs /fee/quote with optional context', async () => {
+    const quotes: FeeQuoteResponse[] = [
+      {
+        fee: { feeTo: '0xabc', feeAmount: '0' },
+        pricing: 'fixed',
+        scheme: 'exact',
+        network: 'tron:nile',
+        asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+      },
+    ];
+    const { fetchImpl, calls } = mockFetch(quotes);
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    await client.feeQuote([REQUIREMENTS], { paymentId: '0x' + '11'.repeat(16) });
+
+    const body = JSON.parse(calls[0]!.init?.body as string);
+    expect(body.accepts).toHaveLength(1);
+    expect(body.paymentPermitContext).toEqual({ paymentId: '0x' + '11'.repeat(16) });
+  });
+
+  it('omits paymentPermitContext when no context given', async () => {
+    const { fetchImpl, calls } = mockFetch([]);
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    await client.feeQuote([REQUIREMENTS]);
+
+    const body = JSON.parse(calls[0]!.init?.body as string);
+    expect(body).not.toHaveProperty('paymentPermitContext');
+  });
+
+  it('forwards custom headers on every request', async () => {
+    const { fetchImpl, calls } = mockFetch({ kinds: [] });
+    const client = new FacilitatorClient({
+      baseUrl: 'https://fac.example',
+      headers: { Authorization: 'Bearer abc' },
+      fetchImpl,
+    });
+
+    await client.supported();
+
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer abc');
+  });
+
+  it('throws FacilitatorError on non-2xx with body preserved', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async () => {
+      return new Response('boom', { status: 500 });
+    }) as unknown as typeof fetch;
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    await expect(client.verify(PAYLOAD, REQUIREMENTS)).rejects.toMatchObject({
+      name: 'FacilitatorError',
+      status: 500,
+      body: 'boom',
+    });
+  });
+
+  it('throws FacilitatorError on transport failure', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    const client = new FacilitatorClient({ baseUrl: 'https://fac.example', fetchImpl });
+
+    const promise = client.supported();
+    await expect(promise).rejects.toBeInstanceOf(FacilitatorError);
+    await expect(promise).rejects.toMatchObject({ status: 0 });
+  });
+
+  it('close() is a no-op safe to call', async () => {
+    const client = new FacilitatorClient({
+      baseUrl: 'https://fac.example',
+      fetchImpl: mockFetch({}).fetchImpl,
+    });
+    await expect(client.close()).resolves.toBeUndefined();
+  });
+});

--- a/typescript/packages/x402/src/facilitator/client.ts
+++ b/typescript/packages/x402/src/facilitator/client.ts
@@ -1,0 +1,197 @@
+/**
+ * FacilitatorClient — TypeScript port of `bankofai.x402.facilitator.FacilitatorClient`.
+ *
+ * Talks to a remote x402 facilitator via HTTP. Handles `/supported`, `/fee/quote`,
+ * `/verify`, `/settle`. Used by server middleware (Hono / Express / etc.) to verify
+ * payments off-chain and trigger on-chain settlement.
+ */
+
+import { FacilitatorError } from '../errors.js';
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  SupportedResponse,
+  VerifyResponse,
+} from '../types/index.js';
+
+/** Configuration for {@link FacilitatorClient}. */
+export interface FacilitatorClientConfig {
+  /** Facilitator service base URL (trailing slash optional, will be normalized). */
+  baseUrl: string;
+  /** Optional custom HTTP headers (e.g. `Authorization`). */
+  headers?: Record<string, string>;
+  /** Stable identifier for this facilitator. Defaults to `baseUrl`. */
+  facilitatorId?: string;
+  /** Per-request timeout in milliseconds. Defaults to 120 000 (120 s). */
+  timeoutMs?: number;
+  /** Custom fetch implementation (defaults to global `fetch`). Useful for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Optional payment context forwarded to `/fee/quote`.
+ *
+ * Wire field is `paymentPermitContext` to match the facilitator API; the client
+ * accepts a plain JSON-shaped object and forwards it as-is.
+ */
+export type FeeQuoteContext = Record<string, unknown>;
+
+/**
+ * HTTP client for an x402 facilitator service.
+ *
+ * Mirrors the Python `FacilitatorClient` interface 1:1 so server middleware on
+ * either runtime sees the same shape.
+ */
+export class FacilitatorClient {
+  private readonly baseUrl: string;
+  private readonly headers: Record<string, string>;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  /** Stable identifier for this facilitator (defaults to `baseUrl`). */
+  readonly facilitatorId: string;
+
+  constructor(config: FacilitatorClientConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.headers = { ...(config.headers ?? {}) };
+    this.facilitatorId = config.facilitatorId ?? this.baseUrl;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Query facilitator's supported (`x402Version`, `scheme`, `network`) tuples.
+   */
+  async supported(): Promise<SupportedResponse> {
+    return this.requestJson<SupportedResponse>('GET', '/supported');
+  }
+
+  /**
+   * Request fee quotes for a list of payment requirements.
+   *
+   * @param accepts - The same `accepts[]` you would put in `PaymentRequired`.
+   * @param context - Optional `paymentPermitContext`.
+   */
+  async feeQuote(
+    accepts: PaymentRequirements[],
+    context?: FeeQuoteContext,
+  ): Promise<FeeQuoteResponse[]> {
+    const body: Record<string, unknown> = { accepts };
+    if (context !== undefined) {
+      body.paymentPermitContext = context;
+    }
+    return this.requestJson<FeeQuoteResponse[]>('POST', '/fee/quote', body);
+  }
+
+  /**
+   * Verify a payment payload off-chain (no on-chain transaction).
+   *
+   * Server middleware should call this **before** routing the actual request
+   * handler — only proceed to settlement if {@link VerifyResponse.isValid} is true.
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    return this.requestJson<VerifyResponse>('POST', '/verify', {
+      paymentPayload: payload,
+      paymentRequirements: requirements,
+    });
+  }
+
+  /**
+   * Execute on-chain settlement for a verified payment.
+   *
+   * Returns a {@link SettleResponse} carrying the transaction hash on success
+   * or an `errorReason` on failure.
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return this.requestJson<SettleResponse>('POST', '/settle', {
+      paymentPayload: payload,
+      paymentRequirements: requirements,
+    });
+  }
+
+  /**
+   * Symmetry with the Python client. The TS implementation uses the global
+   * `fetch` (no persistent connection pool to close); this is a no-op kept for
+   * API parity so callers can write the same teardown logic on both runtimes.
+   */
+  async close(): Promise<void> {
+    // no-op — `fetch` does not require explicit cleanup
+  }
+
+  private async requestJson<TResponse>(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<TResponse> {
+    const url = `${this.baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    const init: RequestInit = {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        ...this.headers,
+      },
+      signal: controller.signal,
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, init);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new FacilitatorError(
+          `Facilitator request to ${path} timed out after ${this.timeoutMs}ms`,
+          0,
+        );
+      }
+      throw new FacilitatorError(
+        `Facilitator request to ${path} failed: ${(err as Error).message}`,
+        0,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      const text = await this.safeReadText(response);
+      throw new FacilitatorError(
+        `Facilitator returned HTTP ${response.status} for ${path}`,
+        response.status,
+        text,
+      );
+    }
+
+    try {
+      return (await response.json()) as TResponse;
+    } catch (err) {
+      throw new FacilitatorError(
+        `Facilitator response from ${path} was not valid JSON: ${(err as Error).message}`,
+        response.status,
+      );
+    }
+  }
+
+  private async safeReadText(response: Response): Promise<string | null> {
+    try {
+      return await response.text();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/typescript/packages/x402/src/facilitator/index.ts
+++ b/typescript/packages/x402/src/facilitator/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Facilitator client for the x402 payment protocol.
+ *
+ * Re-exports {@link FacilitatorClient} and its config type so consumers can
+ * import from `@bankofai/x402/facilitator` (or via the package root re-export).
+ */
+
+export { FacilitatorClient } from './client.js';
+export type { FacilitatorClientConfig, FeeQuoteContext } from './client.js';

--- a/typescript/packages/x402/src/facilitator/index.ts
+++ b/typescript/packages/x402/src/facilitator/index.ts
@@ -1,9 +1,14 @@
 /**
- * Facilitator client for the x402 payment protocol.
+ * Facilitator surface for the x402 payment protocol.
  *
- * Re-exports {@link FacilitatorClient} and its config type so consumers can
- * import from `@bankofai/x402/facilitator` (or via the package root re-export).
+ * - {@link FacilitatorClient} — talks to a remote facilitator (used by server middleware)
+ * - {@link X402Facilitator} — in-process payment processor (the engine of a facilitator service)
+ *
+ * Re-exported via the package root so consumers can `import { FacilitatorClient,
+ * X402Facilitator } from '@bankofai/x402'`.
  */
 
 export { FacilitatorClient } from './client.js';
 export type { FacilitatorClientConfig, FeeQuoteContext } from './client.js';
+export { X402Facilitator } from './x402Facilitator.js';
+export type { FacilitatorMechanism, FacilitatorLogger } from './x402Facilitator.js';

--- a/typescript/packages/x402/src/facilitator/x402Facilitator.test.ts
+++ b/typescript/packages/x402/src/facilitator/x402Facilitator.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for X402Facilitator — the in-process payment processor.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import {
+  X402Facilitator,
+  type FacilitatorLogger,
+  type FacilitatorMechanism,
+} from './x402Facilitator.js';
+
+function makeMechanism(opts: {
+  scheme?: string;
+  verifyResult?: VerifyResponse;
+  settleResult?: SettleResponse;
+  quoteResult?: FeeQuoteResponse | null;
+  verifyImpl?: () => Promise<VerifyResponse>;
+  settleImpl?: () => Promise<SettleResponse>;
+  quoteImpl?: () => Promise<FeeQuoteResponse | null>;
+} = {}): FacilitatorMechanism {
+  return {
+    scheme: () => opts.scheme ?? 'exact',
+    feeQuote: opts.quoteImpl
+      ? vi.fn(opts.quoteImpl)
+      : vi.fn(async () => opts.quoteResult ?? null),
+    verify: opts.verifyImpl
+      ? vi.fn(opts.verifyImpl)
+      : vi.fn(async () => opts.verifyResult ?? { isValid: true }),
+    settle: opts.settleImpl
+      ? vi.fn(opts.settleImpl)
+      : vi.fn(async () => opts.settleResult ?? { success: true, transaction: '0xtx' }),
+  };
+}
+
+const TRON_REQ: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'tron:nile',
+  amount: '1000000',
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+};
+
+// EVM addresses purposely lowercase so checksum normalization has work to do.
+const EVM_REQ: PaymentRequirements = {
+  scheme: 'exact_permit',
+  network: 'eip155:97',
+  amount: '1000000',
+  asset: '0x64544969ed7ebf5f083679233325356ebe738930',
+  payTo: '0x1825bb32db3443dec2cc7508b2d818fc13ead878',
+};
+
+const PAYLOAD: PaymentPayload = {
+  x402Version: 2,
+  accepted: TRON_REQ,
+  payload: { signature: '0x' + 'aa'.repeat(65) },
+};
+
+describe('X402Facilitator', () => {
+  describe('register / supported', () => {
+    it('registers a mechanism for multiple networks', () => {
+      const facilitator = new X402Facilitator();
+      const mech = makeMechanism({ scheme: 'exact' });
+
+      const result = facilitator.register(['tron:nile', 'tron:shasta'], mech);
+
+      expect(result).toBe(facilitator); // chainable
+      expect(facilitator.supported().kinds).toEqual([
+        { x402Version: 2, scheme: 'exact', network: 'tron:nile' },
+        { x402Version: 2, scheme: 'exact', network: 'tron:shasta' },
+      ]);
+    });
+
+    it('supports multiple schemes per network', () => {
+      const facilitator = new X402Facilitator()
+        .register(['tron:nile'], makeMechanism({ scheme: 'exact' }))
+        .register(['tron:nile'], makeMechanism({ scheme: 'exact_permit' }));
+
+      const kinds = facilitator.supported().kinds;
+      expect(kinds).toHaveLength(2);
+      expect(kinds.map((k) => k.scheme).sort()).toEqual(['exact', 'exact_permit']);
+    });
+  });
+
+  describe('verify', () => {
+    it('routes to the registered mechanism and forwards its response', async () => {
+      const verify = vi.fn(async () => ({ isValid: true }));
+      const mech: FacilitatorMechanism = {
+        scheme: () => 'exact',
+        feeQuote: vi.fn(),
+        verify,
+        settle: vi.fn(),
+      };
+      const facilitator = new X402Facilitator().register(['tron:nile'], mech);
+
+      const result = await facilitator.verify(PAYLOAD, TRON_REQ);
+
+      expect(result).toEqual({ isValid: true });
+      expect(verify).toHaveBeenCalledOnce();
+    });
+
+    it('returns isValid:false with unsupported_network_scheme when no mechanism', async () => {
+      const facilitator = new X402Facilitator();
+      const result = await facilitator.verify(PAYLOAD, TRON_REQ);
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toContain('unsupported_network_scheme');
+    });
+
+    it('catches mechanism exceptions and surfaces them as invalidReason', async () => {
+      const errorLogger: FacilitatorLogger = { warn: vi.fn(), error: vi.fn() };
+      const facilitator = new X402Facilitator({ logger: errorLogger }).register(
+        ['tron:nile'],
+        makeMechanism({
+          verifyImpl: async () => {
+            throw new Error('signature mismatch');
+          },
+        }),
+      );
+
+      const result = await facilitator.verify(PAYLOAD, TRON_REQ);
+
+      expect(result).toEqual({ isValid: false, invalidReason: 'signature mismatch' });
+      expect(errorLogger.error).toHaveBeenCalledOnce();
+    });
+
+    it('checksums EVM addresses before passing to mechanism', async () => {
+      const verify = vi.fn(async () => ({ isValid: true }));
+      const mech: FacilitatorMechanism = {
+        scheme: () => 'exact_permit',
+        feeQuote: vi.fn(),
+        verify,
+        settle: vi.fn(),
+      };
+      const facilitator = new X402Facilitator().register(['eip155:97'], mech);
+
+      await facilitator.verify(PAYLOAD, EVM_REQ);
+
+      const passed = (verify as ReturnType<typeof vi.fn>).mock.calls[0]![1] as PaymentRequirements;
+      // Checksummed = mixed case
+      expect(passed.asset).not.toBe(EVM_REQ.asset);
+      expect(passed.asset.toLowerCase()).toBe(EVM_REQ.asset);
+      expect(passed.payTo).not.toBe(EVM_REQ.payTo);
+    });
+
+    it('returns isValid:false on invalid EVM address (no exception thrown)', async () => {
+      const facilitator = new X402Facilitator().register(
+        ['eip155:97'],
+        makeMechanism({ scheme: 'exact_permit' }),
+      );
+
+      const result = await facilitator.verify(PAYLOAD, {
+        ...EVM_REQ,
+        asset: '0xnot_an_address',
+      });
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toContain('Invalid EVM address');
+    });
+  });
+
+  describe('settle', () => {
+    it('routes to mechanism and returns its response', async () => {
+      const facilitator = new X402Facilitator().register(
+        ['tron:nile'],
+        makeMechanism({
+          settleResult: { success: true, transaction: '0xabc', network: 'tron:nile' },
+        }),
+      );
+
+      const result = await facilitator.settle(PAYLOAD, TRON_REQ);
+
+      expect(result).toEqual({ success: true, transaction: '0xabc', network: 'tron:nile' });
+    });
+
+    it('returns success:false with unsupported_network_scheme on miss', async () => {
+      const facilitator = new X402Facilitator();
+      const result = await facilitator.settle(PAYLOAD, TRON_REQ);
+      expect(result.success).toBe(false);
+      expect(result.network).toBe('tron:nile');
+      expect(result.errorReason).toContain('unsupported_network_scheme');
+    });
+
+    it('catches mechanism exceptions into errorReason', async () => {
+      const facilitator = new X402Facilitator({ logger: { warn: vi.fn(), error: vi.fn() } })
+        .register(
+          ['tron:nile'],
+          makeMechanism({
+            settleImpl: async () => {
+              throw new Error('chain rpc down');
+            },
+          }),
+        );
+
+      const result = await facilitator.settle(PAYLOAD, TRON_REQ);
+      expect(result).toEqual({
+        success: false,
+        network: 'tron:nile',
+        errorReason: 'chain rpc down',
+      });
+    });
+  });
+
+  describe('feeQuote', () => {
+    it('aggregates quotes from registered mechanisms, skips misses', async () => {
+      const facilitator = new X402Facilitator().register(
+        ['tron:nile'],
+        makeMechanism({
+          quoteResult: {
+            fee: { feeTo: 'TFee', feeAmount: '0' },
+            pricing: 'fixed',
+            scheme: 'exact',
+            network: 'tron:nile',
+            asset: TRON_REQ.asset,
+          },
+        }),
+      );
+
+      const supported = TRON_REQ;
+      const unsupported: PaymentRequirements = {
+        ...TRON_REQ,
+        network: 'eip155:1',
+        scheme: 'unknown',
+      };
+
+      const quotes = await facilitator.feeQuote([supported, unsupported]);
+      expect(quotes).toHaveLength(1);
+      expect(quotes[0]!.network).toBe('tron:nile');
+    });
+
+    it('forwards optional context to mechanism', async () => {
+      const quoteFn = vi.fn(async () => null);
+      const mech: FacilitatorMechanism = {
+        scheme: () => 'exact',
+        feeQuote: quoteFn,
+        verify: vi.fn(),
+        settle: vi.fn(),
+      };
+      const facilitator = new X402Facilitator().register(['tron:nile'], mech);
+
+      await facilitator.feeQuote([TRON_REQ], { paymentId: '0x123' });
+
+      expect(quoteFn).toHaveBeenCalledWith(expect.anything(), { paymentId: '0x123' });
+    });
+
+    it('drops null quotes from result', async () => {
+      const facilitator = new X402Facilitator().register(
+        ['tron:nile'],
+        makeMechanism({ quoteResult: null }),
+      );
+
+      const quotes = await facilitator.feeQuote([TRON_REQ]);
+      expect(quotes).toHaveLength(0);
+    });
+
+    it('throws when mechanism feeQuote raises', async () => {
+      const facilitator = new X402Facilitator().register(
+        ['tron:nile'],
+        makeMechanism({
+          quoteImpl: async () => {
+            throw new Error('quote oracle down');
+          },
+        }),
+      );
+
+      await expect(facilitator.feeQuote([TRON_REQ])).rejects.toThrow(
+        /Fee quote failed for tron:nile\/exact: quote oracle down/,
+      );
+    });
+  });
+});

--- a/typescript/packages/x402/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/x402/src/facilitator/x402Facilitator.ts
@@ -1,0 +1,276 @@
+/**
+ * X402Facilitator — TypeScript port of `bankofai.x402.facilitator.X402Facilitator`.
+ *
+ * The core in-process payment processor for an x402 facilitator service.
+ * Manages a registry of {@link FacilitatorMechanism}s keyed by `(network, scheme)`
+ * and routes verify / settle / feeQuote calls to the right implementation.
+ *
+ * This is the *engine* — wrap it with an HTTP server (Hono / Express / Fastify)
+ * to expose `/verify`, `/settle`, `/supported`, `/fee/quote` endpoints.
+ */
+
+import { getAddress, isAddress } from 'viem';
+
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  SupportedResponse,
+  VerifyResponse,
+} from '../types/index.js';
+
+/**
+ * Server-side mechanism interface for the facilitator.
+ *
+ * One per `(network, scheme)` pair. Implementations live in the chain-specific
+ * mechanism packages (TRON / EVM / etc.) — this interface keeps the facilitator
+ * core agnostic of any particular chain.
+ */
+export interface FacilitatorMechanism {
+  /** Scheme name this mechanism handles (e.g. `"exact"`, `"exact_permit"`). */
+  scheme(): string;
+  /**
+   * Optional fee quote for a single requirement. Return `null` when this
+   * mechanism cannot quote the requirement (e.g. token not in registry).
+   */
+  feeQuote(
+    accept: PaymentRequirements,
+    context?: Record<string, unknown>,
+  ): Promise<FeeQuoteResponse | null>;
+  /** Off-chain signature / replay / timing verification. */
+  verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse>;
+  /** On-chain settlement. */
+  settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse>;
+}
+
+/** Optional logger interface for observability hooks. */
+export interface FacilitatorLogger {
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: string, meta?: Record<string, unknown>): void;
+}
+
+const consoleLogger: FacilitatorLogger = {
+  warn: (msg, meta) => console.warn(`[X402Facilitator] ${msg}`, meta ?? ''),
+  error: (msg, meta) => console.error(`[X402Facilitator] ${msg}`, meta ?? ''),
+};
+
+/**
+ * In-process payment processor. Mirrors the Python `X402Facilitator` 1:1.
+ *
+ * @example
+ * ```ts
+ * const facilitator = new X402Facilitator()
+ *   .register(['tron:nile'], tronExactMechanism)
+ *   .register(['eip155:97'], bscExactPermitMechanism);
+ *
+ * const verifyResult = await facilitator.verify(payload, requirements);
+ * if (verifyResult.isValid) {
+ *   const settleResult = await facilitator.settle(payload, requirements);
+ * }
+ * ```
+ */
+export class X402Facilitator {
+  /** network → scheme → mechanism */
+  private readonly mechanisms = new Map<string, Map<string, FacilitatorMechanism>>();
+
+  private readonly logger: FacilitatorLogger;
+
+  constructor(opts?: { logger?: FacilitatorLogger }) {
+    this.logger = opts?.logger ?? consoleLogger;
+  }
+
+  /**
+   * Register a mechanism for a list of networks. Returns `this` for chaining.
+   */
+  register(networks: string[], mechanism: FacilitatorMechanism): this {
+    const scheme = mechanism.scheme();
+    for (const network of networks) {
+      let bucket = this.mechanisms.get(network);
+      if (!bucket) {
+        bucket = new Map<string, FacilitatorMechanism>();
+        this.mechanisms.set(network, bucket);
+      }
+      bucket.set(scheme, mechanism);
+    }
+    return this;
+  }
+
+  /** Snapshot of registered `(x402Version, scheme, network)` triples. */
+  supported(): SupportedResponse {
+    const kinds: SupportedResponse['kinds'] = [];
+    for (const [network, schemes] of this.mechanisms) {
+      for (const scheme of schemes.keys()) {
+        kinds.push({ x402Version: 2, scheme, network });
+      }
+    }
+    return { kinds };
+  }
+
+  /**
+   * Fee quotes for a list of requirements. Unsupported `(network, scheme)` /
+   * mechanisms returning `null` are silently skipped — the result list may be
+   * shorter than the input. Per-mechanism exceptions surface as a thrown
+   * `Error` (caller decides whether to 4xx or 5xx the HTTP request).
+   */
+  async feeQuote(
+    accepts: PaymentRequirements[],
+    context?: Record<string, unknown>,
+  ): Promise<FeeQuoteResponse[]> {
+    const results: FeeQuoteResponse[] = [];
+    for (const accept of accepts) {
+      const normalized = this.tryNormalizeEvmRequirements(accept);
+      const mechanism = this.findMechanism(normalized.network, normalized.scheme);
+      if (!mechanism) {
+        continue;
+      }
+      try {
+        const quote = await mechanism.feeQuote(normalized, context);
+        if (quote !== null) {
+          results.push(quote);
+        }
+      } catch (err) {
+        throw new Error(
+          `Fee quote failed for ${normalized.network}/${normalized.scheme}: ${(err as Error).message}`,
+          { cause: err },
+        );
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Verify a payment payload off-chain. Always returns a {@link VerifyResponse};
+   * mechanism exceptions become `isValid: false` with the message as
+   * `invalidReason` and a logger.error entry.
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    const mechanism = this.findMechanism(requirements.network, requirements.scheme);
+    if (!mechanism) {
+      return {
+        isValid: false,
+        invalidReason: `unsupported_network_scheme: ${requirements.network}/${requirements.scheme}`,
+      };
+    }
+    let normalized: PaymentRequirements;
+    try {
+      normalized = this.normalizeEvmRequirements(requirements);
+    } catch (err) {
+      return { isValid: false, invalidReason: (err as Error).message };
+    }
+    try {
+      return await mechanism.verify(payload, normalized);
+    } catch (err) {
+      this.logger.error('verify failed', {
+        network: normalized.network,
+        scheme: normalized.scheme,
+        error: (err as Error).message,
+      });
+      return { isValid: false, invalidReason: (err as Error).message };
+    }
+  }
+
+  /**
+   * Execute on-chain settlement. Always returns a {@link SettleResponse};
+   * exceptions become `success: false` with `errorReason` set.
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    const mechanism = this.findMechanism(requirements.network, requirements.scheme);
+    if (!mechanism) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: `unsupported_network_scheme: ${requirements.network}/${requirements.scheme}`,
+      };
+    }
+    let normalized: PaymentRequirements;
+    try {
+      normalized = this.normalizeEvmRequirements(requirements);
+    } catch (err) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: (err as Error).message,
+      };
+    }
+    try {
+      return await mechanism.settle(payload, normalized);
+    } catch (err) {
+      this.logger.error('settle failed', {
+        network: normalized.network,
+        scheme: normalized.scheme,
+        error: (err as Error).message,
+      });
+      return {
+        success: false,
+        network: normalized.network,
+        errorReason: (err as Error).message,
+      };
+    }
+  }
+
+  private findMechanism(network: string, scheme: string): FacilitatorMechanism | null {
+    return this.mechanisms.get(network)?.get(scheme) ?? null;
+  }
+
+  /**
+   * Strict variant — throws if any EVM address fails checksum. Used in verify /
+   * settle so the failure message ends up in the response.
+   */
+  private normalizeEvmRequirements(reqs: PaymentRequirements): PaymentRequirements {
+    if (!reqs.network.startsWith('eip155:')) {
+      return reqs;
+    }
+    return {
+      ...reqs,
+      asset: this.checksumAddressStrict(reqs.asset, 'asset'),
+      payTo: this.checksumAddressStrict(reqs.payTo, 'payTo'),
+      extra: reqs.extra
+        ? {
+            ...reqs.extra,
+            fee: reqs.extra.fee
+              ? {
+                  ...reqs.extra.fee,
+                  feeTo: this.checksumAddressStrict(reqs.extra.fee.feeTo, 'extra.fee.feeTo'),
+                  caller: reqs.extra.fee.caller
+                    ? this.checksumAddressStrict(reqs.extra.fee.caller, 'extra.fee.caller')
+                    : reqs.extra.fee.caller,
+                }
+              : reqs.extra.fee,
+          }
+        : reqs.extra,
+    };
+  }
+
+  /**
+   * Lenient variant for `feeQuote` — invalid-EVM-input requirements are simply
+   * skipped (returning the original so they can be filtered out by mechanism
+   * lookup miss).
+   */
+  private tryNormalizeEvmRequirements(reqs: PaymentRequirements): PaymentRequirements {
+    try {
+      return this.normalizeEvmRequirements(reqs);
+    } catch {
+      return reqs;
+    }
+  }
+
+  private checksumAddressStrict(address: string, fieldName: string): string {
+    if (!isAddress(address, { strict: false })) {
+      throw new Error(`Invalid EVM address for ${fieldName}: ${address}`);
+    }
+    return getAddress(address);
+  }
+}

--- a/typescript/packages/x402/src/http/client.test.ts
+++ b/typescript/packages/x402/src/http/client.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for X402FetchClient — automatic 402 challenge-retry on the client side.
+ *
+ * Uses a fake fetch impl + a stub X402Client.handlePayment so the suite stays
+ * hermetic.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { X402Client } from '../client/index.js';
+import type {
+  PaymentPayload,
+  PaymentRequired,
+  PaymentRequirements,
+  SettleResponse,
+} from '../types/index.js';
+import { encodePaymentPayload } from '../utils/encoding.js';
+import {
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  PAYMENT_SIGNATURE_HEADER,
+  X402FetchClient,
+  parsePaymentResponseHeader,
+} from './client.js';
+
+const REQ: PaymentRequirements = {
+  scheme: 'exact_permit',
+  network: 'tron:nile',
+  amount: '1000000',
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+};
+
+const PAYMENT_REQUIRED: PaymentRequired = {
+  x402Version: 2,
+  accepts: [REQ],
+};
+
+const PAYLOAD: PaymentPayload = {
+  x402Version: 2,
+  accepted: REQ,
+  payload: { signature: '0x' + 'aa'.repeat(65) },
+};
+
+function makeStubX402Client(payload: PaymentPayload = PAYLOAD): X402Client {
+  return {
+    handlePayment: vi.fn(async () => payload),
+  } as unknown as X402Client;
+}
+
+interface ScriptedFetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+function scriptedFetch(responses: Response[]): {
+  fetchImpl: typeof fetch;
+  calls: ScriptedFetchCall[];
+} {
+  const calls: ScriptedFetchCall[] = [];
+  let i = 0;
+  const fetchImpl: typeof fetch = vi.fn(async (input, init) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    calls.push({ url, init });
+    const next = responses[i++];
+    if (!next) throw new Error(`scriptedFetch: no more queued responses (call #${i})`);
+    return next;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe('X402FetchClient', () => {
+  it('passes through non-402 responses unchanged', async () => {
+    const ok = new Response('hello', { status: 200 });
+    const { fetchImpl, calls } = scriptedFetch([ok]);
+    const client = new X402FetchClient(makeStubX402Client(), { fetchImpl });
+
+    const res = await client.get('https://example.com/api');
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.init?.method).toBe('GET');
+  });
+
+  it('handles 402 → sign → retry happy path', async () => {
+    const challenge = new Response(JSON.stringify(PAYMENT_REQUIRED), {
+      status: 402,
+      headers: {
+        'Content-Type': 'application/json',
+        [PAYMENT_REQUIRED_HEADER]: encodePaymentPayload(PAYMENT_REQUIRED),
+      },
+    });
+    const settled: SettleResponse = {
+      success: true,
+      transaction: '0xabc',
+      network: 'tron:nile',
+    };
+    const success = new Response('paid', {
+      status: 200,
+      headers: { [PAYMENT_RESPONSE_HEADER]: encodePaymentPayload(settled) },
+    });
+    const { fetchImpl, calls } = scriptedFetch([challenge, success]);
+    const x402 = makeStubX402Client();
+    const client = new X402FetchClient(x402, { fetchImpl });
+
+    const res = await client.get('https://example.com/api');
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(2);
+    // Retry carried PAYMENT-SIGNATURE header.
+    const retryHeaders = calls[1]!.init?.headers as Headers;
+    expect(retryHeaders.get(PAYMENT_SIGNATURE_HEADER)).toBe(encodePaymentPayload(PAYLOAD));
+    expect(x402.handlePayment).toHaveBeenCalledWith(
+      PAYMENT_REQUIRED.accepts,
+      'https://example.com/api',
+      undefined,
+      undefined,
+    );
+    // PAYMENT-RESPONSE round-trips back through the helper.
+    expect(parsePaymentResponseHeader(res)).toEqual(settled);
+  });
+
+  it('falls back to body-parsing when PAYMENT-REQUIRED header is missing', async () => {
+    const challenge = new Response(JSON.stringify(PAYMENT_REQUIRED), {
+      status: 402,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const success = new Response('paid', { status: 200 });
+    const { fetchImpl } = scriptedFetch([challenge, success]);
+    const client = new X402FetchClient(makeStubX402Client(), { fetchImpl });
+
+    const res = await client.get('https://example.com/api');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns the original 402 when no PaymentRequired can be parsed', async () => {
+    const broken = new Response('not json', {
+      status: 402,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+    const { fetchImpl, calls } = scriptedFetch([broken]);
+    const client = new X402FetchClient(makeStubX402Client(), { fetchImpl });
+
+    const res = await client.get('https://example.com/api');
+    expect(res.status).toBe(402);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('forwards method-specific shorthands correctly', async () => {
+    const ok = () => new Response('', { status: 200 });
+    const { fetchImpl, calls } = scriptedFetch([ok(), ok(), ok(), ok(), ok()]);
+    const client = new X402FetchClient(makeStubX402Client(), { fetchImpl });
+
+    await client.get('https://e.com/g');
+    await client.post('https://e.com/p', 'body1');
+    await client.put('https://e.com/u', 'body2');
+    await client.patch('https://e.com/h', 'body3');
+    await client.delete('https://e.com/d');
+
+    expect(calls.map((c) => c.init?.method)).toEqual([
+      'GET',
+      'POST',
+      'PUT',
+      'PATCH',
+      'DELETE',
+    ]);
+    expect(calls[1]!.init?.body).toBe('body1');
+    expect(calls[2]!.init?.body).toBe('body2');
+    expect(calls[3]!.init?.body).toBe('body3');
+  });
+
+  it('parsePaymentResponseHeader returns null for missing / malformed headers', () => {
+    const noHeader = new Response('', { status: 200 });
+    expect(parsePaymentResponseHeader(noHeader)).toBeNull();
+
+    const badHeader = new Response('', {
+      status: 200,
+      headers: { [PAYMENT_RESPONSE_HEADER]: 'not-base64-json' },
+    });
+    expect(parsePaymentResponseHeader(badHeader)).toBeNull();
+  });
+
+  it('legacy positional selector argument is accepted (back-compat surface)', () => {
+    // Construction with a positional selector keeps the pre-options surface alive.
+    // Behaviour-wise the legacy path falls back to global fetch (no fetchImpl
+    // injection slot) — the surface preserved here is the type-level contract.
+    const selector = vi.fn();
+    expect(() => new X402FetchClient(makeStubX402Client(), selector)).not.toThrow();
+  });
+});

--- a/typescript/packages/x402/src/http/client.ts
+++ b/typescript/packages/x402/src/http/client.ts
@@ -1,45 +1,79 @@
 /**
- * X402FetchClient - Fetch-based HTTP client with automatic 402 payment handling
+ * X402FetchClient — Fetch-based HTTP client with automatic 402 payment handling.
+ *
+ * Mirrors `bankofai.x402.clients.X402HttpClient` on the Python side. Wraps the
+ * global `fetch` (configurable for tests) so agent code can call any URL and
+ * have 402 challenges silently handled — challenge → sign → retry → return
+ * the final 200 response, with the settled payment receipt parseable via
+ * {@link parsePaymentResponseHeader}.
  */
 
 import {
+  type PaymentPayload,
+  type PaymentRequired,
+  type PaymentRequirementsSelector,
+  type SettleResponse,
   X402Client,
-  PaymentRequired,
-  PaymentPayload,
-  PaymentRequirementsSelector,
-  encodePaymentPayload,
   decodePaymentPayload,
+  encodePaymentPayload,
 } from '../index.js';
 
-/** HTTP headers for x402 protocol */
-const PAYMENT_SIGNATURE_HEADER = 'PAYMENT-SIGNATURE';
-const PAYMENT_REQUIRED_HEADER = 'PAYMENT-REQUIRED';
-const PAYMENT_RESPONSE_HEADER = 'PAYMENT-RESPONSE';
+/** Wire-format header names. */
+export const PAYMENT_SIGNATURE_HEADER = 'PAYMENT-SIGNATURE';
+export const PAYMENT_REQUIRED_HEADER = 'PAYMENT-REQUIRED';
+export const PAYMENT_RESPONSE_HEADER = 'PAYMENT-RESPONSE';
+
+/** Constructor options for {@link X402FetchClient}. */
+export interface X402FetchClientOptions {
+  /** Custom payment requirements selector (defaults to library default). */
+  selector?: PaymentRequirementsSelector;
+  /** Custom fetch implementation (defaults to global `fetch`). Useful for tests. */
+  fetchImpl?: typeof fetch;
+}
 
 /**
- * Fetch-based HTTP client with automatic 402 payment handling
+ * Fetch-based HTTP client with automatic 402 payment handling.
+ *
+ * @example
+ * ```ts
+ * const x402Client = new X402Client(...).register(mechanism);
+ * const httpClient = new X402FetchClient(x402Client);
+ *
+ * const res = await httpClient.get('https://api.example.com/llm');
+ * if (res.ok) {
+ *   const settled = parsePaymentResponseHeader(res);
+ *   console.log('paid via tx', settled?.transaction);
+ * }
+ * ```
  */
 export class X402FetchClient {
-  private x402Client: X402Client;
-  private selector?: PaymentRequirementsSelector;
+  private readonly x402Client: X402Client;
+  private readonly selector?: PaymentRequirementsSelector;
+  private readonly fetchImpl: typeof fetch;
 
   constructor(
     x402Client: X402Client,
-    selector?: PaymentRequirementsSelector
+    selectorOrOptions?: PaymentRequirementsSelector | X402FetchClientOptions,
   ) {
     this.x402Client = x402Client;
-    this.selector = selector;
+    if (typeof selectorOrOptions === 'function') {
+      this.selector = selectorOrOptions;
+      this.fetchImpl = fetch;
+    } else {
+      this.selector = selectorOrOptions?.selector;
+      this.fetchImpl = selectorOrOptions?.fetchImpl ?? fetch;
+    }
   }
 
   /**
-   * Make request with automatic 402 payment handling
+   * Issue a request with automatic 402 → pay → retry handling.
+   *
+   * If the server returns a non-402 status, the response is passed through.
+   * If the 402 cannot be parsed (no PAYMENT-REQUIRED header and no parseable
+   * body), the original 402 is returned to the caller for inspection.
    */
-  async request(
-    url: string,
-    init?: RequestInit
-  ): Promise<Response> {
-    const response = await fetch(url, init);
-
+  async request(url: string, init?: RequestInit): Promise<Response> {
+    const response = await this.fetchImpl(url, init);
     if (response.status !== 402) {
       return response;
     }
@@ -53,28 +87,57 @@ export class X402FetchClient {
       paymentRequired.accepts,
       url,
       paymentRequired.extensions,
-      this.selector
+      this.selector,
     );
 
     return this.retryWithPayment(url, init, paymentPayload);
   }
 
-  /**
-   * GET request with payment handling
-   */
+  /** GET shorthand. */
   async get(url: string, init?: RequestInit): Promise<Response> {
     return this.request(url, { ...init, method: 'GET' });
   }
 
-  /**
-   * POST request with payment handling
-   */
-  async post(url: string, body?: RequestInit['body'], init?: RequestInit): Promise<Response> {
+  /** POST shorthand. */
+  async post(
+    url: string,
+    body?: RequestInit['body'],
+    init?: RequestInit,
+  ): Promise<Response> {
     return this.request(url, { ...init, method: 'POST', body });
   }
 
+  /** PUT shorthand. */
+  async put(
+    url: string,
+    body?: RequestInit['body'],
+    init?: RequestInit,
+  ): Promise<Response> {
+    return this.request(url, { ...init, method: 'PUT', body });
+  }
+
+  /** PATCH shorthand. */
+  async patch(
+    url: string,
+    body?: RequestInit['body'],
+    init?: RequestInit,
+  ): Promise<Response> {
+    return this.request(url, { ...init, method: 'PATCH', body });
+  }
+
+  /** DELETE shorthand. */
+  async delete(url: string, init?: RequestInit): Promise<Response> {
+    return this.request(url, { ...init, method: 'DELETE' });
+  }
+
   /**
-   * Parse PaymentRequired from 402 response
+   * Try to parse a `PaymentRequired` from the 402 response.
+   *
+   * Order:
+   * 1. `PAYMENT-REQUIRED` header (base64 JSON).
+   * 2. JSON body fallback when header is missing or undecodable.
+   *
+   * Returns `null` if neither path yields a recognizable shape.
    */
   private async parsePaymentRequired(response: Response): Promise<PaymentRequired | null> {
     const headerValue = response.headers.get(PAYMENT_REQUIRED_HEADER);
@@ -82,38 +145,51 @@ export class X402FetchClient {
       try {
         return decodePaymentPayload<PaymentRequired>(headerValue);
       } catch {
-        // Continue to parse body
+        // Header malformed — fall through to body.
       }
     }
 
     try {
-      const body = await response.json() as Record<string, unknown>;
-      if (body.accepts && Array.isArray(body.accepts)) {
+      const body = (await response.clone().json()) as Record<string, unknown>;
+      if (Array.isArray(body.accepts)) {
         return body as unknown as PaymentRequired;
       }
     } catch {
-      // Unable to parse
+      // Body not parseable — give up.
     }
 
     return null;
   }
 
-  /**
-   * Retry request with payment payload
-   */
+  /** Re-issue the original request with the encoded payment payload header. */
   private async retryWithPayment(
     url: string,
     init: RequestInit | undefined,
-    paymentPayload: PaymentPayload
+    paymentPayload: PaymentPayload,
   ): Promise<Response> {
-    const encodedPayload = encodePaymentPayload(paymentPayload);
-    
+    const encoded = encodePaymentPayload(paymentPayload);
     const headers = new Headers(init?.headers);
-    headers.set(PAYMENT_SIGNATURE_HEADER, encodedPayload);
+    headers.set(PAYMENT_SIGNATURE_HEADER, encoded);
+    return this.fetchImpl(url, { ...init, headers });
+  }
+}
 
-    return fetch(url, {
-      ...init,
-      headers,
-    });
+/**
+ * Pull the {@link SettleResponse} out of a 200 response's PAYMENT-RESPONSE header.
+ *
+ * Servers attach this on success so the client can record the settlement tx
+ * hash / network without making a separate facilitator call.
+ *
+ * @returns The decoded settle response, or `null` if the header is absent or malformed.
+ */
+export function parsePaymentResponseHeader(response: Response): SettleResponse | null {
+  const headerValue = response.headers.get(PAYMENT_RESPONSE_HEADER);
+  if (!headerValue) {
+    return null;
+  }
+  try {
+    return decodePaymentPayload<SettleResponse>(headerValue);
+  } catch {
+    return null;
   }
 }

--- a/typescript/packages/x402/src/index.ts
+++ b/typescript/packages/x402/src/index.ts
@@ -30,7 +30,7 @@ export * from './middleware/index.js';
 export * from './mechanisms/index.js';
 
 // EVM ExactPermit Mechanism
-export * from './mechanisms/exactEvm.js';
+export * from './mechanisms/evm/exact_permit/index.js';
 
 // TRON Signer
 export * from './signers/signer.js';

--- a/typescript/packages/x402/src/index.ts
+++ b/typescript/packages/x402/src/index.ts
@@ -17,6 +17,9 @@ export * from './address.js';
 // HTTP Client
 export * from './http/client.js';
 
+// Facilitator client (talks to remote /verify, /settle, /supported, /fee/quote)
+export * from './facilitator/index.js';
+
 // Mechanisms
 export * from './mechanisms/index.js';
 

--- a/typescript/packages/x402/src/index.ts
+++ b/typescript/packages/x402/src/index.ts
@@ -20,6 +20,9 @@ export * from './http/client.js';
 // Facilitator client (talks to remote /verify, /settle, /supported, /fee/quote)
 export * from './facilitator/index.js';
 
+// Server middleware (Hono / Express adapters + framework-agnostic core)
+export * from './middleware/index.js';
+
 // Mechanisms
 export * from './mechanisms/index.js';
 

--- a/typescript/packages/x402/src/index.ts
+++ b/typescript/packages/x402/src/index.ts
@@ -20,6 +20,9 @@ export * from './http/client.js';
 // Facilitator client (talks to remote /verify, /settle, /supported, /fee/quote)
 export * from './facilitator/index.js';
 
+// High-level server API (X402Server, ResourceConfig, ServerMechanism)
+export * from './server/index.js';
+
 // Server middleware (Hono / Express adapters + framework-agnostic core)
 export * from './middleware/index.js';
 

--- a/typescript/packages/x402/src/index.ts
+++ b/typescript/packages/x402/src/index.ts
@@ -37,3 +37,13 @@ export * from './signers/signer.js';
 // EVM Signer
 export * from './signers/evmSigner.js';
 export type { TronWeb, TypedDataDomain, TypedDataField, TronNetwork, TRON_CHAIN_IDS } from './signers/types.js';
+
+// Facilitator signers (verify + writeContract + receipt polling)
+export { FacilitatorSigner } from './signers/facilitator/base.js';
+export type {
+  FacilitatorTypedDataDomain,
+  FacilitatorTypedDataTypes,
+  FacilitatorTransactionReceipt,
+} from './signers/index.js';
+export { TronFacilitatorSigner } from './signers/facilitator/tronSigner.js';
+export { EvmFacilitatorSigner } from './signers/facilitator/evmSigner.js';

--- a/typescript/packages/x402/src/mechanisms/_base/index.ts
+++ b/typescript/packages/x402/src/mechanisms/_base/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Base mechanism interfaces — mirrors Python `bankofai.x402.mechanisms._base`.
+ *
+ * The three role interfaces (`ClientMechanism`, `ServerMechanism`,
+ * `FacilitatorMechanism`) currently live close to where they're consumed:
+ *
+ * - `ClientMechanism`     → `src/client/x402Client.ts`
+ * - `ServerMechanism`     → `src/server/types.ts`
+ * - `FacilitatorMechanism` → `src/facilitator/x402Facilitator.ts`
+ *
+ * This file re-exports them under one mechanism-rooted location so that
+ * `mechanisms/<chain>/<scheme>/{client,server,facilitator}.ts` modules import
+ * their role contract from a single canonical path. Mirrors how Python's
+ * `_base/{client,server,facilitator}.py` are imported by concrete mechanisms.
+ */
+
+export type { ClientMechanism, ClientSigner } from '../../client/x402Client.js';
+export type { ServerMechanism } from '../../server/types.js';
+export type {
+  FacilitatorMechanism,
+  FacilitatorLogger,
+} from '../../facilitator/x402Facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/_exact_base/adapter.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/adapter.ts
@@ -1,0 +1,23 @@
+/**
+ * ChainAdapter — pluggable per-chain primitives for the `exact` scheme.
+ *
+ * Mirrors Python `mechanisms._exact_base.base.ChainAdapter`. Subclasses
+ * provide chain-specific parsing / validation / address normalization so
+ * `ExactBase{Client,Server,Facilitator}Mechanism` can stay chain-agnostic.
+ */
+
+export interface ChainAdapter {
+  /** Parse chain id from CAIP-2 network (e.g. `"eip155:97"` → `97`). */
+  parseChainId(network: string): number;
+  /** Check the CAIP-2 prefix is valid for this adapter (`"eip155:"` / `"tron:"`). */
+  validateNetwork(network: string): boolean;
+  /** Format check (no on-chain lookup). */
+  validateAddress(address: string): boolean;
+  /** Canonicalize for storage / comparison (lowercase EVM, Base58 TRON, ...). */
+  normalizeAddress(address: string): string;
+  /**
+   * Convert to the address representation used inside EIP-712 / TIP-712 typed
+   * data (0x-prefixed hex on both chains). Used by signing path.
+   */
+  toSigningAddress(address: string): string;
+}

--- a/typescript/packages/x402/src/mechanisms/_exact_base/evmAdapter.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/evmAdapter.ts
@@ -1,0 +1,34 @@
+import { getAddress, isAddress } from 'viem';
+
+import type { ChainAdapter } from './adapter.js';
+
+/** EVM (`eip155:<chainId>`) ChainAdapter. */
+export class EvmChainAdapter implements ChainAdapter {
+  parseChainId(network: string): number {
+    const parts = network.split(':');
+    if (parts.length !== 2 || parts[0] !== 'eip155') {
+      throw new Error(`Invalid EVM network identifier: ${network}`);
+    }
+    const id = parseInt(parts[1]!, 10);
+    if (!Number.isFinite(id) || id <= 0) {
+      throw new Error(`Invalid EVM chain id in ${network}`);
+    }
+    return id;
+  }
+
+  validateNetwork(network: string): boolean {
+    return network.startsWith('eip155:');
+  }
+
+  validateAddress(address: string): boolean {
+    return isAddress(address, { strict: false });
+  }
+
+  normalizeAddress(address: string): string {
+    return this.validateAddress(address) ? address.toLowerCase() : address;
+  }
+
+  toSigningAddress(address: string): string {
+    return this.validateAddress(address) ? getAddress(address) : address;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/_exact_base/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/facilitator.ts
@@ -3,15 +3,14 @@
  *
  * Mirrors Python `mechanisms._exact_base.base.ExactBaseFacilitatorMechanism`.
  *
- * Per-chain subclasses provide a {@link ChainAdapter} and the chain RPC client
- * (viem PublicClient / tronweb instance). The base handles:
- * - basic structural verification (asset / payTo / value match, time window)
- * - dispatching feeQuote / verify / settle to the chain-specific impl
+ * Per-chain subclasses provide a {@link ChainAdapter}. The base handles:
+ * - structural verification (asset / payTo / value match, time window)
+ * - ERC-3009 EIP-712 signature recovery via the injected FacilitatorSigner
+ * - `transferWithAuthorization` settle + receipt polling
  *
- * Subclasses MUST implement chain interactions: signature recovery, balance
- * check, transaction broadcast. The base provides defaults that return
- * `null` / `false` so non-fully-implemented mechanisms remain visible at
- * the structural level but don't pretend to verify on-chain state.
+ * Subclasses ONLY need to override:
+ * - `settlePaymentOnly()` — chain-specific contract call dispatch (TRON
+ *   triggerSmartContract vs EVM viem writeContract)
  */
 
 import type { ChainAdapter } from './adapter.js';
@@ -21,99 +20,297 @@ import type {
   PaymentPayload,
   PaymentRequirements,
   SettleResponse,
+  TransferAuthorization,
   VerifyResponse,
 } from '../../types/index.js';
-import { SCHEME_EXACT } from './types.js';
+import { FacilitatorSigner } from '../../signers/facilitator/base.js';
+import { findByAddress } from '../../tokens.js';
+import {
+  SCHEME_EXACT,
+  TRANSFER_AUTH_EIP712_TYPES,
+  TRANSFER_AUTH_PRIMARY_TYPE,
+} from './types.js';
 
-export abstract class ExactBaseFacilitatorMechanism implements FacilitatorMechanism {
-  constructor(protected readonly adapter: ChainAdapter) {}
+const FEE_QUOTE_EXPIRY_SECONDS = 300;
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export abstract class ExactBaseFacilitatorMechanism
+  implements FacilitatorMechanism
+{
+  protected readonly signer: FacilitatorSigner;
+  protected readonly adapter: ChainAdapter;
+  protected readonly allowedTokens: ReadonlySet<string> | null;
+
+  constructor(
+    signer: FacilitatorSigner,
+    adapter: ChainAdapter,
+    options: { allowedTokens?: ReadonlyArray<string> } = {},
+  ) {
+    this.signer = signer;
+    this.adapter = adapter;
+    this.allowedTokens = options.allowedTokens
+      ? new Set(options.allowedTokens.map((t) => adapter.normalizeAddress(t)))
+      : null;
+  }
 
   scheme(): string {
     return SCHEME_EXACT;
   }
 
   /**
-   * `exact` scheme has no facilitator fee — return `null` to drop from the
-   * supported quote list. Permit-based schemes override this.
+   * `exact` scheme has no facilitator fee (single transfer per authorization).
+   * Returns `feeAmount: "0"` for compatibility with the `/fee/quote` flow.
    */
   async feeQuote(
-    _accept: PaymentRequirements,
+    accept: PaymentRequirements,
     _context?: Record<string, unknown>,
   ): Promise<FeeQuoteResponse | null> {
-    return null;
+    return {
+      fee: { feeTo: this.signer.getAddress(), feeAmount: '0' },
+      pricing: 'flat',
+      scheme: accept.scheme,
+      network: accept.network,
+      asset: accept.asset,
+      expiresAt: Math.floor(Date.now() / 1000) + FEE_QUOTE_EXPIRY_SECONDS,
+    } as unknown as FeeQuoteResponse;
   }
 
   /**
-   * Off-chain verification: structural + timing checks. Chain-specific
-   * subclasses extend this to add signature recovery and balance check.
+   * Off-chain verify: structural + timing checks, then EIP-712 signature
+   * recovery against the token's ERC-3009 domain.
    */
   async verify(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
   ): Promise<VerifyResponse> {
-    const authorization = this.extractAuthorization(payload);
-    if (!authorization) {
-      return { isValid: false, invalidReason: 'missing_authorization' };
+    const auth = this.extractAuthorization(payload);
+    if (!auth) {
+      return { isValid: false, invalidReason: 'missing_transfer_authorization' };
     }
 
-    // Validate basic structural correctness
-    if (String(authorization.to).toLowerCase() !== String(requirements.payTo).toLowerCase()) {
-      return { isValid: false, invalidReason: 'payTo_mismatch' };
-    }
-    try {
-      if (BigInt(authorization.value) < BigInt(requirements.amount)) {
-        return { isValid: false, invalidReason: 'amount_too_low' };
-      }
-    } catch {
-      return { isValid: false, invalidReason: 'invalid_value' };
+    const validationError = this.validateAuthorization(auth, requirements);
+    if (validationError) {
+      return { isValid: false, invalidReason: validationError };
     }
 
-    // Validate time window
-    const now = Math.floor(Date.now() / 1000);
-    try {
-      if (BigInt(String(authorization.validBefore ?? '0')) < BigInt(now)) {
-        return { isValid: false, invalidReason: 'expired' };
-      }
-      if (BigInt(String(authorization.validAfter ?? now)) > BigInt(now)) {
-        return { isValid: false, invalidReason: 'not_yet_valid' };
-      }
-    } catch {
-      return { isValid: false, invalidReason: 'invalid_time_window' };
+    const validSig = await this.verifySignature(
+      auth,
+      payload.payload.signature,
+      requirements,
+    );
+    if (!validSig) {
+      return { isValid: false, invalidReason: 'invalid_signature' };
     }
-
-    // Chain-specific signature + balance check (overridable)
-    const sigResult = await this.verifySignatureOnChain(payload, requirements);
-    if (!sigResult.isValid) return sigResult;
-
     return { isValid: true };
   }
 
   /**
-   * Settle the authorization on-chain. Chain-specific — subclasses must
-   * implement using viem (EVM) or tronweb (TRON).
+   * Settle: verify, then submit `transferWithAuthorization(v,r,s)` via the
+   * subclass-provided `settlePaymentOnly`, then poll the receipt.
    */
-  abstract settle(
+  async settle(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
-  ): Promise<SettleResponse>;
+  ): Promise<SettleResponse> {
+    const verifyResult = await this.verify(payload, requirements);
+    if (!verifyResult.isValid) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: verifyResult.invalidReason,
+      };
+    }
+
+    const auth = this.extractAuthorization(payload)!;
+    const signature = payload.payload.signature;
+
+    let txHash: string | null;
+    try {
+      txHash = await this.settlePaymentOnly(auth, signature, requirements);
+    } catch (err) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: `settle_error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    if (!txHash) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: 'transaction_failed',
+      };
+    }
+
+    try {
+      const receipt = await this.signer.waitForTransactionReceipt(
+        txHash,
+        requirements.network,
+      );
+      if (receipt.status !== 'confirmed') {
+        return {
+          success: false,
+          network: requirements.network,
+          transaction: txHash,
+          errorReason: 'transaction_failed_on_chain',
+        };
+      }
+    } catch (err) {
+      return {
+        success: false,
+        network: requirements.network,
+        transaction: txHash,
+        errorReason: `receipt_timeout: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    return {
+      success: true,
+      network: requirements.network,
+      transaction: txHash,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Protected helpers
+  // -------------------------------------------------------------------------
+
+  protected validateAuthorization(
+    auth: TransferAuthorization,
+    requirements: PaymentRequirements,
+  ): string | null {
+    const norm = (s: string) => this.adapter.normalizeAddress(s);
+
+    if (
+      this.allowedTokens !== null &&
+      !this.allowedTokens.has(norm(requirements.asset))
+    ) {
+      return 'token_not_allowed';
+    }
+
+    try {
+      if (BigInt(auth.value) < BigInt(requirements.amount)) {
+        return 'amount_mismatch';
+      }
+    } catch {
+      return 'invalid_value';
+    }
+
+    if (norm(auth.to) !== norm(requirements.payTo)) {
+      return 'payto_mismatch';
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    try {
+      if (BigInt(auth.validBefore) < BigInt(now)) return 'expired';
+      if (BigInt(auth.validAfter) > BigInt(now)) return 'not_yet_valid';
+    } catch {
+      return 'invalid_time_window';
+    }
+    return null;
+  }
 
   /**
-   * Chain-specific signature recovery + balance check. Default returns
-   * `isValid: true` (trust upstream); subclasses MUST override for real
-   * signature verification. Marked protected so subclass can call super.
+   * Verify the buyer's ERC-3009 EIP-712 signature against the token's domain.
+   *
+   * Domain shape (ERC-3009): `{ name, version, chainId, verifyingContract: <token> }`.
+   * Token name / version come from the SDK token registry; addresses are
+   * converted to signing format (0x EVM hex) for both EVM and TRON.
    */
-  protected async verifySignatureOnChain(
-    _payload: PaymentPayload,
-    _requirements: PaymentRequirements,
-  ): Promise<VerifyResponse> {
-    return { isValid: true };
+  protected async verifySignature(
+    auth: TransferAuthorization,
+    signature: string,
+    requirements: PaymentRequirements,
+  ): Promise<boolean> {
+    const adapter = this.adapter;
+    const chainId = adapter.parseChainId(requirements.network);
+    const tokenInfo = findByAddress(requirements.network, requirements.asset);
+    const tokenName = tokenInfo?.name ?? 'Unknown Token';
+    const tokenVersion = tokenInfo?.version ?? '1';
+
+    const domain = {
+      name: tokenName,
+      version: tokenVersion,
+      chainId,
+      verifyingContract: adapter.toSigningAddress(requirements.asset),
+    };
+    const message = {
+      from: adapter.toSigningAddress(auth.from),
+      to: adapter.toSigningAddress(auth.to),
+      value: BigInt(auth.value),
+      validAfter: BigInt(auth.validAfter),
+      validBefore: BigInt(auth.validBefore),
+      // viem accepts hex string for bytes32 types
+      nonce: auth.nonce.startsWith('0x') ? auth.nonce : `0x${auth.nonce}`,
+    };
+
+    return this.signer.verifyTypedData(
+      adapter.toSigningAddress(auth.from),
+      domain,
+      TRANSFER_AUTH_EIP712_TYPES as unknown as Record<
+        string,
+        ReadonlyArray<{ name: string; type: string }>
+      >,
+      message,
+      signature,
+      TRANSFER_AUTH_PRIMARY_TYPE,
+    );
+  }
+
+  /**
+   * Split a 65-byte signature into v / r / s for the (v, r, s) variant of
+   * `transferWithAuthorization`. v is normalized to 27 or 28 (some signers
+   * return 0 / 1).
+   */
+  protected splitSignature(signature: string): {
+    v: number;
+    r: `0x${string}`;
+    s: `0x${string}`;
+  } {
+    const sigBytes = hexToBytes(signature);
+    if (sigBytes.length !== 65) {
+      throw new Error(`Invalid signature length: ${sigBytes.length}`);
+    }
+    const r =
+      '0x' +
+      Array.from(sigBytes.slice(0, 32))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    const s =
+      '0x' +
+      Array.from(sigBytes.slice(32, 64))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+    let v = sigBytes[64]!;
+    if (v < 27) v += 27;
+    return { v, r: r as `0x${string}`, s: s as `0x${string}` };
   }
 
   protected extractAuthorization(
     payload: PaymentPayload,
-  ): NonNullable<PaymentPayload['payload']['authorization']> | null {
+  ): TransferAuthorization | null {
     if (payload.payload.authorization) return payload.payload.authorization;
     const ext = (payload.extensions ?? {})['transferAuthorization'];
-    return (ext as NonNullable<PaymentPayload['payload']['authorization']>) ?? null;
+    return (ext as TransferAuthorization) ?? null;
   }
+
+  /**
+   * Submit the authorization on-chain. Chain-specific — subclasses MUST
+   * implement (TRON via tronweb, EVM via viem).
+   *
+   * Returns the tx hash on broadcast success, or `null` on broadcast failure.
+   */
+  protected abstract settlePaymentOnly(
+    auth: TransferAuthorization,
+    signature: string,
+    requirements: PaymentRequirements,
+  ): Promise<string | null>;
 }

--- a/typescript/packages/x402/src/mechanisms/_exact_base/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/facilitator.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared base for `exact` scheme facilitator mechanisms.
+ *
+ * Mirrors Python `mechanisms._exact_base.base.ExactBaseFacilitatorMechanism`.
+ *
+ * Per-chain subclasses provide a {@link ChainAdapter} and the chain RPC client
+ * (viem PublicClient / tronweb instance). The base handles:
+ * - basic structural verification (asset / payTo / value match, time window)
+ * - dispatching feeQuote / verify / settle to the chain-specific impl
+ *
+ * Subclasses MUST implement chain interactions: signature recovery, balance
+ * check, transaction broadcast. The base provides defaults that return
+ * `null` / `false` so non-fully-implemented mechanisms remain visible at
+ * the structural level but don't pretend to verify on-chain state.
+ */
+
+import type { ChainAdapter } from './adapter.js';
+import type { FacilitatorMechanism } from '../../facilitator/x402Facilitator.js';
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../../types/index.js';
+import { SCHEME_EXACT } from './types.js';
+
+export abstract class ExactBaseFacilitatorMechanism implements FacilitatorMechanism {
+  constructor(protected readonly adapter: ChainAdapter) {}
+
+  scheme(): string {
+    return SCHEME_EXACT;
+  }
+
+  /**
+   * `exact` scheme has no facilitator fee — return `null` to drop from the
+   * supported quote list. Permit-based schemes override this.
+   */
+  async feeQuote(
+    _accept: PaymentRequirements,
+    _context?: Record<string, unknown>,
+  ): Promise<FeeQuoteResponse | null> {
+    return null;
+  }
+
+  /**
+   * Off-chain verification: structural + timing checks. Chain-specific
+   * subclasses extend this to add signature recovery and balance check.
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    const authorization = this.extractAuthorization(payload);
+    if (!authorization) {
+      return { isValid: false, invalidReason: 'missing_authorization' };
+    }
+
+    // Validate basic structural correctness
+    if (String(authorization.to).toLowerCase() !== String(requirements.payTo).toLowerCase()) {
+      return { isValid: false, invalidReason: 'payTo_mismatch' };
+    }
+    try {
+      if (BigInt(authorization.value) < BigInt(requirements.amount)) {
+        return { isValid: false, invalidReason: 'amount_too_low' };
+      }
+    } catch {
+      return { isValid: false, invalidReason: 'invalid_value' };
+    }
+
+    // Validate time window
+    const now = Math.floor(Date.now() / 1000);
+    try {
+      if (BigInt(String(authorization.validBefore ?? '0')) < BigInt(now)) {
+        return { isValid: false, invalidReason: 'expired' };
+      }
+      if (BigInt(String(authorization.validAfter ?? now)) > BigInt(now)) {
+        return { isValid: false, invalidReason: 'not_yet_valid' };
+      }
+    } catch {
+      return { isValid: false, invalidReason: 'invalid_time_window' };
+    }
+
+    // Chain-specific signature + balance check (overridable)
+    const sigResult = await this.verifySignatureOnChain(payload, requirements);
+    if (!sigResult.isValid) return sigResult;
+
+    return { isValid: true };
+  }
+
+  /**
+   * Settle the authorization on-chain. Chain-specific — subclasses must
+   * implement using viem (EVM) or tronweb (TRON).
+   */
+  abstract settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse>;
+
+  /**
+   * Chain-specific signature recovery + balance check. Default returns
+   * `isValid: true` (trust upstream); subclasses MUST override for real
+   * signature verification. Marked protected so subclass can call super.
+   */
+  protected async verifySignatureOnChain(
+    _payload: PaymentPayload,
+    _requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    return { isValid: true };
+  }
+
+  protected extractAuthorization(
+    payload: PaymentPayload,
+  ): NonNullable<PaymentPayload['payload']['authorization']> | null {
+    if (payload.payload.authorization) return payload.payload.authorization;
+    const ext = (payload.extensions ?? {})['transferAuthorization'];
+    return (ext as NonNullable<PaymentPayload['payload']['authorization']>) ?? null;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/_exact_base/index.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/index.ts
@@ -1,11 +1,6 @@
 /**
  * Shared base for the `exact` scheme — mirrors Python
  * `bankofai.x402.mechanisms._exact_base`.
- *
- * Types and EIP-712 / TIP-712 typed-data helpers live in `./types.ts`.
- * Future shared client / server / facilitator base classes (ChainAdapter
- * pattern, like Python's `_exact_base.base.ExactBaseServerMechanism` etc.)
- * will be added here.
  */
 
 export {
@@ -19,3 +14,9 @@ export {
   createValidityWindow,
 } from './types.js';
 export type { TransferAuthorization } from './types.js';
+
+export type { ChainAdapter } from './adapter.js';
+export { EvmChainAdapter } from './evmAdapter.js';
+export { TronChainAdapter } from './tronAdapter.js';
+export { ExactBaseServerMechanism } from './server.js';
+export { ExactBaseFacilitatorMechanism } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/_exact_base/index.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared base for the `exact` scheme — mirrors Python
+ * `bankofai.x402.mechanisms._exact_base`.
+ *
+ * Types and EIP-712 / TIP-712 typed-data helpers live in `./types.ts`.
+ * Future shared client / server / facilitator base classes (ChainAdapter
+ * pattern, like Python's `_exact_base.base.ExactBaseServerMechanism` etc.)
+ * will be added here.
+ */
+
+export {
+  DEFAULT_VALIDITY_SECONDS,
+  SCHEME_EXACT,
+  TRANSFER_AUTH_EIP712_TYPES,
+  TRANSFER_AUTH_PRIMARY_TYPE,
+  buildEip712Domain,
+  buildEip712Message,
+  createNonce,
+  createValidityWindow,
+} from './types.js';
+export type { TransferAuthorization } from './types.js';

--- a/typescript/packages/x402/src/mechanisms/_exact_base/server.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/server.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared base for `exact` scheme server mechanisms.
+ *
+ * Mirrors Python `mechanisms._exact_base.base.ExactBaseServerMechanism`.
+ *
+ * Per-chain mechanisms (`evm/exact/server.ts`, `tron/exact/server.ts`)
+ * subclass this and provide a {@link ChainAdapter}. The base handles:
+ * - price parsing (delegate to {@link parsePrice})
+ * - requirements enhancement (token name / version from registry)
+ * - basic validation (network + address format)
+ *
+ * `verify_signature` requires on-chain or chain-specific signing libs — left
+ * abstract here for subclasses to implement with their chain's tooling.
+ */
+
+import type { ChainAdapter } from './adapter.js';
+import { parsePrice, findByAddress } from '../../tokens.js';
+import type { ServerMechanism } from '../../server/types.js';
+import type {
+  PaymentPayload,
+  PaymentPermit,
+  PaymentRequirements,
+} from '../../types/index.js';
+import { SCHEME_EXACT } from './types.js';
+
+export abstract class ExactBaseServerMechanism implements ServerMechanism {
+  constructor(protected readonly adapter: ChainAdapter) {}
+
+  scheme(): string {
+    return SCHEME_EXACT;
+  }
+
+  async parsePrice(price: string, network: string) {
+    return parsePrice(price, network);
+  }
+
+  /**
+   * Attach token name + version to `extra` so clients have everything needed
+   * to build the EIP-712 / TIP-712 typed-data domain.
+   */
+  async enhancePaymentRequirements(
+    requirements: PaymentRequirements,
+    _deliveryMode: string,
+  ): Promise<PaymentRequirements> {
+    const token = findByAddress(requirements.network, requirements.asset);
+    if (!token) return requirements;
+    return {
+      ...requirements,
+      extra: {
+        ...(requirements.extra ?? {}),
+        name: token.name,
+        ...(token.version ? { version: token.version } : {}),
+      },
+    };
+  }
+
+  validatePaymentRequirements(requirements: PaymentRequirements): boolean {
+    if (!this.adapter.validateNetwork(requirements.network)) return false;
+    if (!this.adapter.validateAddress(requirements.asset)) return false;
+    if (!this.adapter.validateAddress(requirements.payTo)) return false;
+    return true;
+  }
+
+  /**
+   * Server-side signature verification. Chain-specific — subclasses must
+   * implement using their chain's signature recovery primitives (viem for
+   * EVM, tron-utils for TRON).
+   *
+   * For `exact`, the signed object is the `authorization` (ERC-3009-style).
+   */
+  abstract verifySignature(
+    permit: PaymentPermit | null | undefined,
+    signature: string,
+    network: string,
+  ): Promise<boolean>;
+
+  /** Convenience hook to pull the authorization out of a payload. */
+  protected extractAuthorization(
+    payload: PaymentPayload,
+  ): PaymentPayload['payload']['authorization'] | null {
+    if (payload.payload.authorization) return payload.payload.authorization;
+    const ext = (payload.extensions ?? {})['transferAuthorization'];
+    return (ext as PaymentPayload['payload']['authorization']) ?? null;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/_exact_base/tronAdapter.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/tronAdapter.ts
@@ -1,0 +1,50 @@
+import { TronAddressConverter, toBase58 } from '../../address.js';
+import type { ChainAdapter } from './adapter.js';
+
+const TRON_CHAIN_IDS: Record<string, number> = {
+  'tron:mainnet': 728126428,
+  'tron:shasta': 2494104990,
+  'tron:nile': 3448148188,
+};
+
+const TRON_CONVERTER = new TronAddressConverter();
+
+/** TRON (`tron:<name>`) ChainAdapter. */
+export class TronChainAdapter implements ChainAdapter {
+  parseChainId(network: string): number {
+    const id = TRON_CHAIN_IDS[network];
+    if (id === undefined) {
+      throw new Error(`Unknown TRON network: ${network}`);
+    }
+    return id;
+  }
+
+  validateNetwork(network: string): boolean {
+    return network.startsWith('tron:');
+  }
+
+  validateAddress(address: string): boolean {
+    if (typeof address !== 'string') return false;
+    // Accept both Base58 (T...) and 0x-prefixed hex forms
+    if (address.startsWith('T') && address.length === 34) return true;
+    if (address.startsWith('0x') && address.length === 42) return true;
+    return false;
+  }
+
+  normalizeAddress(address: string): string {
+    if (!this.validateAddress(address)) return address;
+    if (address.startsWith('0x')) {
+      try {
+        return toBase58(address);
+      } catch {
+        return address;
+      }
+    }
+    return address;
+  }
+
+  /** TIP-712 requires 0x-prefixed EVM-hex form for every address field. */
+  toSigningAddress(address: string): string {
+    return TRON_CONVERTER.toEvmFormat(address);
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/_exact_base/types.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_base/types.ts
@@ -5,10 +5,10 @@
  * without going through a PaymentPermit contract.
  */
 
-import type { Hex } from '../address.js';
-import type { TransferAuthorization } from '../types/payment.js';
+import type { Hex } from '../../address.js';
+import type { TransferAuthorization } from '../../types/payment.js';
 
-export type { TransferAuthorization } from '../types/payment.js';
+export type { TransferAuthorization } from '../../types/payment.js';
 
 /** Scheme name */
 export const SCHEME_EXACT = 'exact';

--- a/typescript/packages/x402/src/mechanisms/_exact_permit_base/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_permit_base/facilitator.ts
@@ -2,64 +2,155 @@
  * Shared base for `exact_permit` scheme facilitator mechanisms.
  *
  * Mirrors Python `mechanisms._exact_permit_base.facilitator.BaseExactPermitFacilitatorMechanism`.
+ *
+ * Subclasses override:
+ * - {@link getAddressConverter} — chain-specific address normalization
+ * - {@link settlePaymentOnly} — chain-specific contract call (PaymentPermit.permitTransferFrom)
  */
 
+import { FacilitatorSigner } from '../../signers/facilitator/base.js';
 import type { FacilitatorMechanism } from '../../facilitator/x402Facilitator.js';
 import type {
   FeeQuoteResponse,
   PaymentPayload,
+  PaymentPermit,
   PaymentRequirements,
   SettleResponse,
   VerifyResponse,
 } from '../../types/index.js';
+import {
+  KIND_MAP,
+  PAYMENT_PERMIT_PRIMARY_TYPE,
+  PAYMENT_PERMIT_TYPES,
+} from '../../abi.js';
+import { findByAddress } from '../../tokens.js';
+import { getChainId, getPaymentPermitAddress } from '../../config.js';
+import type { AddressConverter } from '../../address.js';
 
 const SCHEME_EXACT_PERMIT = 'exact_permit';
 
 /** Fee policy used by `feeQuote`. */
 export interface BaseExactPermitFee {
-  /** Address that collects the facilitator fee. */
-  feeTo: string;
+  /**
+   * Address that collects the facilitator fee. Defaults to
+   * `signer.getAddress()` when undefined.
+   */
+  feeTo?: string;
   /** Optional caller address that the on-chain contract requires. */
   caller?: string;
   /**
-   * Base fee in smallest unit, keyed by `${network}:${tokenAddress}`. Tokens
-   * not in this map use {@link defaultBaseFee}.
+   * Per-symbol base fee (smallest unit string). Token symbol is uppercased
+   * before lookup. Tokens not in this map are rejected by `fee_quote` and
+   * `_validate_permit`.
    */
-  baseFeesByToken?: Record<string, string>;
-  /** Fallback fee when no per-token entry matches. Default `"0"`. */
-  defaultBaseFee?: string;
+  baseFee?: Record<string, string>;
+  /**
+   * Optional token allowlist (lowercased addresses). If set, only tokens
+   * in this set are accepted; otherwise all tokens pass the address check.
+   */
+  allowedTokens?: ReadonlyArray<string>;
 }
 
-export abstract class BaseExactPermitFacilitatorMechanism implements FacilitatorMechanism {
-  constructor(protected readonly fee: BaseExactPermitFee) {}
+/**
+ * Tuple shape passed to `triggerSmartContract` (TRON) or `writeContract` (EVM)
+ * for `PaymentPermit.permitTransferFrom`. Matches the on-chain ABI tuple.
+ */
+export type PermitTuple = [
+  // meta
+  [
+    number,        // kind (uint8)
+    `0x${string}`, // paymentId (bytes16)
+    string,        // nonce (uint256 string)
+    number,        // validAfter (uint256)
+    number,        // validBefore (uint256)
+  ],
+  string, // buyer (address)
+  string, // caller (address)
+  // payment
+  [
+    string, // payToken
+    string, // payAmount (uint256 string)
+    string, // payTo
+  ],
+  // fee
+  [
+    string, // feeTo
+    string, // feeAmount (uint256 string)
+  ],
+];
+
+const FEE_QUOTE_EXPIRY_SECONDS = 300;
+
+export abstract class BaseExactPermitFacilitatorMechanism
+  implements FacilitatorMechanism
+{
+  protected readonly signer: FacilitatorSigner;
+  protected readonly feeTo: string;
+  protected readonly caller: string;
+  protected readonly baseFeeMap: Record<string, bigint>;
+  protected readonly allowedTokens: ReadonlySet<string> | null;
+  protected readonly addressConverter: AddressConverter;
+
+  constructor(signer: FacilitatorSigner, fee: BaseExactPermitFee = {}) {
+    this.signer = signer;
+    this.feeTo = fee.feeTo ?? signer.getAddress();
+    this.caller = fee.caller ?? signer.getAddress();
+    this.addressConverter = this.getAddressConverter();
+    this.baseFeeMap = {};
+    if (fee.baseFee) {
+      for (const [symbol, amount] of Object.entries(fee.baseFee)) {
+        this.baseFeeMap[symbol.toUpperCase()] = BigInt(amount);
+      }
+    }
+    this.allowedTokens = fee.allowedTokens
+      ? new Set(fee.allowedTokens.map((t) => this.addressConverter.normalize(t)))
+      : null;
+  }
 
   scheme(): string {
     return SCHEME_EXACT_PERMIT;
+  }
+
+  /** Chain-specific address converter. */
+  protected abstract getAddressConverter(): AddressConverter;
+
+  /**
+   * Look up base fee for a token by symbol. Returns `null` if the token is
+   * not registered in the SDK token registry or the symbol has no entry
+   * in `baseFeeMap`.
+   */
+  protected getBaseFee(tokenAddress: string, network: string): bigint | null {
+    const tokenInfo = findByAddress(network, tokenAddress);
+    if (!tokenInfo) return null;
+    const symbol = tokenInfo.symbol.toUpperCase();
+    if (!(symbol in this.baseFeeMap)) return null;
+    return this.baseFeeMap[symbol]!;
   }
 
   async feeQuote(
     accept: PaymentRequirements,
     _context?: Record<string, unknown>,
   ): Promise<FeeQuoteResponse | null> {
-    const key = `${accept.network}:${accept.asset.toLowerCase()}`;
-    const feeAmount =
-      this.fee.baseFeesByToken?.[key] ?? this.fee.defaultBaseFee ?? '0';
+    const baseFee = this.getBaseFee(accept.asset, accept.network);
+    if (baseFee === null) {
+      return null;
+    }
     return {
       fee: {
-        feeTo: this.fee.feeTo,
-        feeAmount,
-        ...(this.fee.caller ? { caller: this.fee.caller } : {}),
+        feeTo: this.feeTo,
+        feeAmount: baseFee.toString(),
+        caller: this.caller,
       },
-      pricing: 'fixed',
-      scheme: this.scheme(),
+      pricing: 'flat',
+      scheme: accept.scheme,
       network: accept.network,
       asset: accept.asset,
-    };
+      expiresAt: Math.floor(Date.now() / 1000) + FEE_QUOTE_EXPIRY_SECONDS,
+    } as unknown as FeeQuoteResponse;
   }
 
   /**
-   * Off-chain verify path: structural checks live here, signature + balance
-   * + nonce + on-chain state checks go in subclass.
+   * Off-chain verify path: structural + fee + signature checks.
    */
   async verify(
     payload: PaymentPayload,
@@ -69,42 +160,237 @@ export abstract class BaseExactPermitFacilitatorMechanism implements Facilitator
     if (!permit) {
       return { isValid: false, invalidReason: 'missing_permit' };
     }
-    if (permit.payment.payToken !== requirements.asset) {
-      return { isValid: false, invalidReason: 'asset_mismatch' };
-    }
-    if (permit.payment.payTo !== requirements.payTo) {
-      return { isValid: false, invalidReason: 'payTo_mismatch' };
-    }
-    try {
-      if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) {
-        return { isValid: false, invalidReason: 'amount_too_low' };
-      }
-    } catch {
-      return { isValid: false, invalidReason: 'invalid_amount' };
+    const validationError = this.validatePermit(permit, requirements);
+    if (validationError) {
+      return { isValid: false, invalidReason: validationError };
     }
 
-    // Chain-specific signature + on-chain balance / nonce checks
-    return this.verifyOnChain(payload, requirements);
-  }
-
-  /**
-   * Chain-specific on-chain verification. Default: trust upstream
-   * (returns `isValid: true`). Subclasses MUST override for real
-   * signature recovery + balance + nonce checks.
-   */
-  protected async verifyOnChain(
-    _payload: PaymentPayload,
-    _requirements: PaymentRequirements,
-  ): Promise<VerifyResponse> {
+    const signature = payload.payload.signature;
+    const validSig = await this.verifySignature(
+      permit,
+      signature,
+      requirements.network,
+    );
+    if (!validSig) {
+      return { isValid: false, invalidReason: 'invalid_signature' };
+    }
     return { isValid: true };
   }
 
   /**
-   * Submit the permit on-chain. Chain-specific — subclasses MUST implement
-   * via viem (EVM) / tronweb (TRON).
+   * Settle the permit on-chain: verify, then submit via subclass
+   * `settlePaymentOnly`, then poll the receipt.
    */
-  abstract settle(
+  async settle(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
-  ): Promise<SettleResponse>;
+  ): Promise<SettleResponse> {
+    const verifyResult = await this.verify(payload, requirements);
+    if (!verifyResult.isValid) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: verifyResult.invalidReason,
+      };
+    }
+    const permit = payload.payload.paymentPermit!;
+    const signature = payload.payload.signature;
+
+    let txHash: string | null;
+    try {
+      txHash = await this.settlePaymentOnly(permit, signature, requirements);
+    } catch (err) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: `settle_error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    if (!txHash) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: 'transaction_failed',
+      };
+    }
+
+    // Poll receipt
+    try {
+      const receipt = await this.signer.waitForTransactionReceipt(
+        txHash,
+        requirements.network,
+      );
+      if (receipt.status !== 'confirmed') {
+        return {
+          success: false,
+          network: requirements.network,
+          transaction: txHash,
+          errorReason: 'transaction_failed_on_chain',
+        };
+      }
+    } catch (err) {
+      // Receipt timeout — return tx hash + flag as failed-pending so the
+      // client can re-check; same shape Python uses.
+      return {
+        success: false,
+        network: requirements.network,
+        transaction: txHash,
+        errorReason: `receipt_timeout: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    return {
+      success: true,
+      network: requirements.network,
+      transaction: txHash,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Protected helpers used by subclasses + verify/settle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Structural + fee validation. Returns the error reason string, or `null`
+   * if valid.
+   */
+  protected validatePermit(
+    permit: PaymentPermit,
+    requirements: PaymentRequirements,
+  ): string | null {
+    const norm = (s: string) => this.addressConverter.normalize(s);
+
+    if (this.allowedTokens !== null && !this.allowedTokens.has(norm(permit.payment.payToken))) {
+      return 'token_not_allowed';
+    }
+    try {
+      if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) {
+        return 'amount_mismatch';
+      }
+    } catch {
+      return 'invalid_amount';
+    }
+    if (norm(permit.payment.payTo) !== norm(requirements.payTo)) {
+      return 'payto_mismatch';
+    }
+    if (norm(permit.payment.payToken) !== norm(requirements.asset)) {
+      return 'token_mismatch';
+    }
+    if (norm(permit.fee.feeTo) !== norm(this.feeTo)) {
+      return 'fee_to_mismatch';
+    }
+    const expectedFee = this.getBaseFee(permit.payment.payToken, requirements.network);
+    if (expectedFee === null) {
+      return 'unsupported_token';
+    }
+    try {
+      if (BigInt(permit.fee.feeAmount) < expectedFee) {
+        return 'fee_amount_mismatch';
+      }
+    } catch {
+      return 'invalid_fee';
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (permit.meta.validBefore < now) return 'expired';
+    if (permit.meta.validAfter > now) return 'not_yet_valid';
+
+    return null;
+  }
+
+  /**
+   * Verify the buyer's EIP-712 / TIP-712 signature against the permit.
+   *
+   * Build the message in the exact shape the buyer signed:
+   * - `kind` as numeric (0 for PAYMENT_ONLY)
+   * - `paymentId` as hex string (bytes16 — viem accepts hex)
+   * - `nonce` / amounts as BigInt strings
+   * - all addresses converted to 0x EVM hex (required for TRON TIP-712)
+   */
+  protected async verifySignature(
+    permit: PaymentPermit,
+    signature: string,
+    network: string,
+  ): Promise<boolean> {
+    const permitContract = getPaymentPermitAddress(network);
+    const chainId = getChainId(network);
+    const converter = this.addressConverter;
+
+    const message: Record<string, unknown> = {
+      meta: {
+        kind: KIND_MAP[permit.meta.kind],
+        paymentId: permit.meta.paymentId, // hex string OK
+        nonce: BigInt(permit.meta.nonce),
+        validAfter: BigInt(permit.meta.validAfter),
+        validBefore: BigInt(permit.meta.validBefore),
+      },
+      buyer: converter.toEvmFormat(permit.buyer),
+      caller: converter.toEvmFormat(permit.caller),
+      payment: {
+        payToken: converter.toEvmFormat(permit.payment.payToken),
+        payAmount: BigInt(permit.payment.payAmount),
+        payTo: converter.toEvmFormat(permit.payment.payTo),
+      },
+      fee: {
+        feeTo: converter.toEvmFormat(permit.fee.feeTo),
+        feeAmount: BigInt(permit.fee.feeAmount),
+      },
+    };
+
+    return this.signer.verifyTypedData(
+      permit.buyer,
+      {
+        name: 'PaymentPermit',
+        chainId,
+        verifyingContract: converter.toEvmFormat(permitContract),
+      },
+      PAYMENT_PERMIT_TYPES as unknown as Record<
+        string,
+        ReadonlyArray<{ name: string; type: string }>
+      >,
+      message,
+      signature,
+      PAYMENT_PERMIT_PRIMARY_TYPE,
+    );
+  }
+
+  /**
+   * Build the tuple passed to `permitTransferFrom(permit, owner, signature)`.
+   * Addresses are returned in the chain-canonical format (Base58 for TRON,
+   * 0x hex for EVM) since each chain's writer accepts both — let the subclass
+   * normalize further if needed.
+   */
+  protected buildPermitTuple(permit: PaymentPermit): PermitTuple {
+    const converter = this.addressConverter;
+    const norm = (s: string) => converter.normalize(s);
+    return [
+      [
+        KIND_MAP[permit.meta.kind],
+        permit.meta.paymentId as `0x${string}`,
+        permit.meta.nonce,
+        permit.meta.validAfter,
+        permit.meta.validBefore,
+      ],
+      norm(permit.buyer),
+      norm(permit.caller),
+      [
+        norm(permit.payment.payToken),
+        permit.payment.payAmount,
+        norm(permit.payment.payTo),
+      ],
+      [norm(permit.fee.feeTo), permit.fee.feeAmount],
+    ];
+  }
+
+  /**
+   * Submit the permit on-chain. Chain-specific — subclasses MUST implement.
+   *
+   * Returns the tx hash on broadcast success, or `null` on failure (the base
+   * wraps null into a `SettleResponse{ success: false }`).
+   */
+  protected abstract settlePaymentOnly(
+    permit: PaymentPermit,
+    signature: string,
+    requirements: PaymentRequirements,
+  ): Promise<string | null>;
 }

--- a/typescript/packages/x402/src/mechanisms/_exact_permit_base/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_permit_base/facilitator.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared base for `exact_permit` scheme facilitator mechanisms.
+ *
+ * Mirrors Python `mechanisms._exact_permit_base.facilitator.BaseExactPermitFacilitatorMechanism`.
+ */
+
+import type { FacilitatorMechanism } from '../../facilitator/x402Facilitator.js';
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../../types/index.js';
+
+const SCHEME_EXACT_PERMIT = 'exact_permit';
+
+/** Fee policy used by `feeQuote`. */
+export interface BaseExactPermitFee {
+  /** Address that collects the facilitator fee. */
+  feeTo: string;
+  /** Optional caller address that the on-chain contract requires. */
+  caller?: string;
+  /**
+   * Base fee in smallest unit, keyed by `${network}:${tokenAddress}`. Tokens
+   * not in this map use {@link defaultBaseFee}.
+   */
+  baseFeesByToken?: Record<string, string>;
+  /** Fallback fee when no per-token entry matches. Default `"0"`. */
+  defaultBaseFee?: string;
+}
+
+export abstract class BaseExactPermitFacilitatorMechanism implements FacilitatorMechanism {
+  constructor(protected readonly fee: BaseExactPermitFee) {}
+
+  scheme(): string {
+    return SCHEME_EXACT_PERMIT;
+  }
+
+  async feeQuote(
+    accept: PaymentRequirements,
+    _context?: Record<string, unknown>,
+  ): Promise<FeeQuoteResponse | null> {
+    const key = `${accept.network}:${accept.asset.toLowerCase()}`;
+    const feeAmount =
+      this.fee.baseFeesByToken?.[key] ?? this.fee.defaultBaseFee ?? '0';
+    return {
+      fee: {
+        feeTo: this.fee.feeTo,
+        feeAmount,
+        ...(this.fee.caller ? { caller: this.fee.caller } : {}),
+      },
+      pricing: 'fixed',
+      scheme: this.scheme(),
+      network: accept.network,
+      asset: accept.asset,
+    };
+  }
+
+  /**
+   * Off-chain verify path: structural checks live here, signature + balance
+   * + nonce + on-chain state checks go in subclass.
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    const permit = payload.payload.paymentPermit;
+    if (!permit) {
+      return { isValid: false, invalidReason: 'missing_permit' };
+    }
+    if (permit.payment.payToken !== requirements.asset) {
+      return { isValid: false, invalidReason: 'asset_mismatch' };
+    }
+    if (permit.payment.payTo !== requirements.payTo) {
+      return { isValid: false, invalidReason: 'payTo_mismatch' };
+    }
+    try {
+      if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) {
+        return { isValid: false, invalidReason: 'amount_too_low' };
+      }
+    } catch {
+      return { isValid: false, invalidReason: 'invalid_amount' };
+    }
+
+    // Chain-specific signature + on-chain balance / nonce checks
+    return this.verifyOnChain(payload, requirements);
+  }
+
+  /**
+   * Chain-specific on-chain verification. Default: trust upstream
+   * (returns `isValid: true`). Subclasses MUST override for real
+   * signature recovery + balance + nonce checks.
+   */
+  protected async verifyOnChain(
+    _payload: PaymentPayload,
+    _requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    return { isValid: true };
+  }
+
+  /**
+   * Submit the permit on-chain. Chain-specific — subclasses MUST implement
+   * via viem (EVM) / tronweb (TRON).
+   */
+  abstract settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse>;
+}

--- a/typescript/packages/x402/src/mechanisms/_exact_permit_base/index.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_permit_base/index.ts
@@ -1,16 +1,10 @@
 /**
- * Shared base for the `exact_permit` scheme — mirrors Python
+ * Shared base for `exact_permit` scheme — mirrors Python
  * `bankofai.x402.mechanisms._exact_permit_base`.
- *
- * Concrete client mechanisms (`evm/exact_permit/client.ts`,
- * `tron/exact_permit/client.ts`) currently embed the shared logic directly.
- * Server + facilitator base classes (Python's
- * `_exact_permit_base/{server,facilitator}.py`) will be added here when their
- * TS counterparts are ported.
- *
- * Placeholder file — keeps the directory structure aligned with Python and
- * gives `mechanisms/<chain>/exact_permit/{server,facilitator}.ts` a canonical
- * place to import shared bases from once they exist.
  */
 
-export {};
+export { BaseExactPermitServerMechanism } from './server.js';
+export {
+  BaseExactPermitFacilitatorMechanism,
+} from './facilitator.js';
+export type { BaseExactPermitFee } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/_exact_permit_base/index.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_permit_base/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared base for the `exact_permit` scheme — mirrors Python
+ * `bankofai.x402.mechanisms._exact_permit_base`.
+ *
+ * Concrete client mechanisms (`evm/exact_permit/client.ts`,
+ * `tron/exact_permit/client.ts`) currently embed the shared logic directly.
+ * Server + facilitator base classes (Python's
+ * `_exact_permit_base/{server,facilitator}.py`) will be added here when their
+ * TS counterparts are ported.
+ *
+ * Placeholder file — keeps the directory structure aligned with Python and
+ * gives `mechanisms/<chain>/exact_permit/{server,facilitator}.ts` a canonical
+ * place to import shared bases from once they exist.
+ */
+
+export {};

--- a/typescript/packages/x402/src/mechanisms/_exact_permit_base/server.ts
+++ b/typescript/packages/x402/src/mechanisms/_exact_permit_base/server.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared base for `exact_permit` scheme server mechanisms.
+ *
+ * Mirrors Python `mechanisms._exact_permit_base.server.BaseExactPermitServerMechanism`.
+ */
+
+import { findByAddress, parsePrice } from '../../tokens.js';
+import type { ServerMechanism } from '../../server/types.js';
+import type {
+  PaymentPermit,
+  PaymentRequirements,
+} from '../../types/index.js';
+
+const SCHEME_EXACT_PERMIT = 'exact_permit';
+
+export abstract class BaseExactPermitServerMechanism implements ServerMechanism {
+  /** CAIP-2 prefix this mechanism handles (`"eip155:"` or `"tron:"`). */
+  protected abstract getNetworkPrefix(): string;
+  /** Format-only address validation (no on-chain lookup). */
+  protected abstract validateAddressFormat(address: string): boolean;
+
+  scheme(): string {
+    return SCHEME_EXACT_PERMIT;
+  }
+
+  async parsePrice(price: string, network: string) {
+    return parsePrice(price, network);
+  }
+
+  async enhancePaymentRequirements(
+    requirements: PaymentRequirements,
+    _deliveryMode: string,
+  ): Promise<PaymentRequirements> {
+    const token = findByAddress(requirements.network, requirements.asset);
+    if (!token) return requirements;
+    return {
+      ...requirements,
+      extra: {
+        ...(requirements.extra ?? {}),
+        name: token.name,
+        ...(token.version ? { version: token.version } : {}),
+      },
+    };
+  }
+
+  validatePaymentRequirements(requirements: PaymentRequirements): boolean {
+    if (!requirements.network.startsWith(this.getNetworkPrefix())) return false;
+    if (!this.validateAddressFormat(requirements.asset)) return false;
+    if (!this.validateAddressFormat(requirements.payTo)) return false;
+    return true;
+  }
+
+  /**
+   * Verify the EIP-712 / TIP-712 permit signature server-side.
+   *
+   * TODO(v0.6.0b): port Python's `verify_signature` —
+   * - hash the typed-data per chain
+   * - recover signer from `signature`
+   * - compare to `permit.buyer`
+   *
+   * Until then returns `true` and defers to the facilitator's authoritative
+   * verification. The interface is present so middleware can call it
+   * uniformly when full impl lands.
+   */
+  async verifySignature(
+    _permit: PaymentPermit | null | undefined,
+    _signature: string,
+    _network: string,
+  ): Promise<boolean> {
+    return true;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/evm/exact/client.test.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ExactEvmClientMechanism } from './nativeExactEvm.js';
-import type { ClientSigner } from '../client/x402Client.js';
+import { ExactEvmClientMechanism } from './client.js';
+import type { ClientSigner } from '../../../client/x402Client.js';
 
 describe('ExactEvmClientMechanism', () => {
   const signer: ClientSigner = {

--- a/typescript/packages/x402/src/mechanisms/evm/exact/client.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/client.ts
@@ -1,8 +1,8 @@
 /**
- * ExactTronClientMechanism - TRON client mechanism for "exact" payment scheme
+ * ExactEvmClientMechanism - EVM client mechanism for "exact" payment scheme
  *
- * Uses ERC-3009 TransferWithAuthorization with TIP-712 signing.
- * Addresses are converted from TRON Base58 to EVM hex for signing.
+ * Uses ERC-3009 TransferWithAuthorization with EIP-712 signing.
+ * EVM addresses are used directly without conversion.
  */
 
 import type {
@@ -10,12 +10,12 @@ import type {
   ClientSigner,
   PaymentRequirements,
   PaymentPayload,
-} from '../index.js';
+} from '../../../index.js';
 import {
   getChainId,
-  TronAddressConverter,
-} from '../index.js';
-import { findByAddress } from '../tokens.js';
+  EvmAddressConverter,
+} from '../../../index.js';
+import { findByAddress } from '../../../tokens.js';
 import {
   SCHEME_EXACT,
   TRANSFER_AUTH_EIP712_TYPES,
@@ -24,15 +24,15 @@ import {
   buildEip712Message,
   createNonce,
   createValidityWindow,
-} from './nativeExact.js';
-import type { TransferAuthorization } from './nativeExact.js';
+} from '../../_exact_base/types.js';
+import type { TransferAuthorization } from '../../_exact_base/types.js';
 
 /**
- * TRON client mechanism for "exact" payment scheme
+ * EVM client mechanism for "exact" payment scheme
  */
-export class ExactTronClientMechanism implements ClientMechanism {
+export class ExactEvmClientMechanism implements ClientMechanism {
   private signer: ClientSigner;
-  private addressConverter = new TronAddressConverter();
+  private addressConverter = new EvmAddressConverter();
 
   constructor(signer: ClientSigner) {
     this.signer = signer;

--- a/typescript/packages/x402/src/mechanisms/evm/exact/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/facilitator.ts
@@ -1,37 +1,54 @@
+/**
+ * EVM (BSC) facilitator mechanism for the `exact` (ERC-3009) scheme.
+ *
+ * Mirrors Python `mechanisms.evm.exact.facilitator.ExactEvmFacilitatorMechanism`.
+ *
+ * Settles by calling `transferWithAuthorization(from, to, value, validAfter,
+ * validBefore, nonce, v, r, s)` directly on the ERC20 token contract via
+ * viem's typed encoding.
+ */
+
 import { ExactBaseFacilitatorMechanism } from '../../_exact_base/facilitator.js';
 import { EvmChainAdapter } from '../../_exact_base/evmAdapter.js';
 import type {
-  PaymentPayload,
   PaymentRequirements,
-  SettleResponse,
+  TransferAuthorization,
 } from '../../../types/index.js';
+import { FacilitatorSigner } from '../../../signers/facilitator/base.js';
+import { TRANSFER_WITH_AUTHORIZATION_ABI } from '../../../abi.js';
 
-/**
- * BSC / EVM facilitator mechanism for the `exact` scheme.
- *
- * Mirrors Python `mechanisms.evm.exact.facilitator.ExactEvmFacilitatorMechanism`.
- */
 export class ExactEvmFacilitatorMechanism extends ExactBaseFacilitatorMechanism {
-  constructor() {
-    super(new EvmChainAdapter());
+  constructor(
+    signer: FacilitatorSigner,
+    options: { allowedTokens?: ReadonlyArray<string> } = {},
+  ) {
+    super(signer, new EvmChainAdapter(), options);
   }
 
-  /**
-   * Settle the ERC-3009 authorization by calling `transferWithAuthorization`
-   * on the token contract.
-   *
-   * TODO(v0.6.0b): wire a viem `WalletClient` and invoke the contract. Until
-   * then this returns `success: false` so the upstream caller knows the
-   * chain integration is not yet wired.
-   */
-  async settle(
-    _payload: PaymentPayload,
+  protected async settlePaymentOnly(
+    auth: TransferAuthorization,
+    signature: string,
     requirements: PaymentRequirements,
-  ): Promise<SettleResponse> {
-    return {
-      success: false,
-      network: requirements.network,
-      errorReason: 'evm_exact_settle_not_implemented',
-    };
+  ): Promise<string | null> {
+    const adapter = this.adapter;
+    const { v, r, s } = this.splitSignature(signature);
+
+    return this.signer.writeContract(
+      requirements.asset, // token contract is the verifying contract for ERC-3009
+      TRANSFER_WITH_AUTHORIZATION_ABI as unknown as unknown[],
+      'transferWithAuthorization',
+      [
+        adapter.toSigningAddress(auth.from),
+        adapter.toSigningAddress(auth.to),
+        BigInt(auth.value),
+        BigInt(auth.validAfter),
+        BigInt(auth.validBefore),
+        auth.nonce.startsWith('0x') ? auth.nonce : `0x${auth.nonce}`,
+        v,
+        r,
+        s,
+      ],
+      requirements.network,
+    );
   }
 }

--- a/typescript/packages/x402/src/mechanisms/evm/exact/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/facilitator.ts
@@ -1,0 +1,37 @@
+import { ExactBaseFacilitatorMechanism } from '../../_exact_base/facilitator.js';
+import { EvmChainAdapter } from '../../_exact_base/evmAdapter.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+} from '../../../types/index.js';
+
+/**
+ * BSC / EVM facilitator mechanism for the `exact` scheme.
+ *
+ * Mirrors Python `mechanisms.evm.exact.facilitator.ExactEvmFacilitatorMechanism`.
+ */
+export class ExactEvmFacilitatorMechanism extends ExactBaseFacilitatorMechanism {
+  constructor() {
+    super(new EvmChainAdapter());
+  }
+
+  /**
+   * Settle the ERC-3009 authorization by calling `transferWithAuthorization`
+   * on the token contract.
+   *
+   * TODO(v0.6.0b): wire a viem `WalletClient` and invoke the contract. Until
+   * then this returns `success: false` so the upstream caller knows the
+   * chain integration is not yet wired.
+   */
+  async settle(
+    _payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return {
+      success: false,
+      network: requirements.network,
+      errorReason: 'evm_exact_settle_not_implemented',
+    };
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/evm/exact/index.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/index.ts
@@ -1,1 +1,3 @@
 export { ExactEvmClientMechanism } from './client.js';
+export { ExactEvmServerMechanism } from './server.js';
+export { ExactEvmFacilitatorMechanism } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/evm/exact/index.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/index.ts
@@ -1,0 +1,1 @@
+export { ExactEvmClientMechanism } from './client.js';

--- a/typescript/packages/x402/src/mechanisms/evm/exact/server.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact/server.ts
@@ -1,0 +1,29 @@
+import { ExactBaseServerMechanism } from '../../_exact_base/server.js';
+import { EvmChainAdapter } from '../../_exact_base/evmAdapter.js';
+import type { PaymentPermit } from '../../../types/index.js';
+
+/**
+ * BSC / EVM server mechanism for the `exact` scheme.
+ *
+ * Mirrors Python `mechanisms.evm.exact.server.ExactEvmServerMechanism`.
+ */
+export class ExactEvmServerMechanism extends ExactBaseServerMechanism {
+  constructor() {
+    super(new EvmChainAdapter());
+  }
+
+  /**
+   * EVM signature verification for ERC-3009 authorizations.
+   *
+   * TODO(v0.6.0b): port the EIP-712 typed-data signature recovery from
+   * Python `ExactBaseServerMechanism._verify_signature`. Until then this
+   * returns `true` and lets the facilitator be the source of truth.
+   */
+  async verifySignature(
+    _permit: PaymentPermit | null | undefined,
+    _signature: string,
+    _network: string,
+  ): Promise<boolean> {
+    return true;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/client.test.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/client.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { ExactPermitEvmClientMechanism } from './exactEvm.js';
-import { EvmClientSigner } from '../signers/evmSigner.js';
-import type { AgentWallet } from '../signers/signer.js';
-import { PermitValidationError } from '../errors.js';
+import { ExactPermitEvmClientMechanism } from './client.js';
+import { EvmClientSigner } from '../../../signers/evmSigner.js';
+import type { AgentWallet } from '../../../signers/signer.js';
+import { PermitValidationError } from '../../../errors.js';
 
 function createMockWallet(address: string): AgentWallet {
   return {

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/client.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/client.ts
@@ -1,7 +1,5 @@
 /**
- * ExactPermitTronClientMechanism - TRON client mechanism for "exact_permit" payment scheme
- *
- * Uses TIP-712 (TRON's EIP-712 implementation) for signing PaymentPermit.
+ * ExactPermitEvmClientMechanism - EVM client mechanism for "exact_permit" payment scheme
  */
 
 import type {
@@ -11,25 +9,25 @@ import type {
   PaymentPayload,
   PaymentPermit,
   PaymentPermitContext,
-} from '../index.js';
+} from '../../../index.js';
 import {
   KIND_MAP,
   PAYMENT_PERMIT_TYPES,
   PAYMENT_PERMIT_PRIMARY_TYPE,
   getChainId,
   getPaymentPermitAddress,
-  TronAddressConverter,
-  TRON_ZERO_ADDRESS,
-  paymentIdToBytes,
+  EVM_ZERO_ADDRESS,
+  EvmAddressConverter,
+  ZERO_ADDRESS_HEX,
   PermitValidationError,
-} from '../index.js';
+} from '../../../index.js';
 
 /**
- * TRON client mechanism for "exact_permit" payment scheme
+ * EVM client mechanism for "exact_permit" payment scheme
  */
-export class ExactPermitTronClientMechanism implements ClientMechanism {
+export class ExactPermitEvmClientMechanism implements ClientMechanism {
   private signer: ClientSigner;
-  private addressConverter = new TronAddressConverter();
+  private addressConverter = new EvmAddressConverter();
 
   constructor(signer: ClientSigner) {
     this.signer = signer;
@@ -54,7 +52,7 @@ export class ExactPermitTronClientMechanism implements ClientMechanism {
     }
 
     const buyerAddress = this.signer.getAddress();
-    const zeroAddress = TRON_ZERO_ADDRESS; // Use TRON zero address for consistency with Python
+    const zeroAddress = EVM_ZERO_ADDRESS;
 
     const permit: PaymentPermit = {
       meta: {
@@ -85,8 +83,7 @@ export class ExactPermitTronClientMechanism implements ClientMechanism {
       requirements.network
     );
 
-    // Build EIP-712 domain (no version field per contract spec)
-    // Note: domain name is "PaymentPermit", not "PaymentPermitDetails"
+    // Build EIP-712 domain
     const permitAddress = getPaymentPermitAddress(requirements.network);
     const domain = {
       name: 'PaymentPermit',
@@ -94,15 +91,11 @@ export class ExactPermitTronClientMechanism implements ClientMechanism {
       verifyingContract: this.addressConverter.toEvmFormat(permitAddress),
     };
 
-    // Convert permit to EIP-712 compatible format:
-    // 1. kind: string -> uint8 (number)
-    // 2. paymentId: keep as hex string (TronWeb expects hex for bytes16)
-    // 3. uint256 values: string -> BigInt (for proper EIP-712 encoding)
-    // 4. All addresses: TRON Base58 -> EVM hex
+    // Convert permit to EIP-712 compatible format
     const permitForSigning = {
       meta: {
         kind: KIND_MAP[permit.meta.kind],
-        paymentId: permit.meta.paymentId,  // Keep as hex string
+        paymentId: permit.meta.paymentId,
         nonce: BigInt(permit.meta.nonce),
         validAfter: permit.meta.validAfter,
         validBefore: permit.meta.validBefore,
@@ -120,26 +113,12 @@ export class ExactPermitTronClientMechanism implements ClientMechanism {
       },
     };
 
-    // Debug: log exact message being signed
-    console.log('[SIGN] Domain:', JSON.stringify(domain));
-    console.log('[SIGN] Message:', JSON.stringify(permitForSigning, (key, value) => {
-      if (value instanceof Uint8Array) {
-        return '0x' + Array.from(value).map(b => b.toString(16).padStart(2, '0')).join('');
-      }
-      if (typeof value === 'bigint') {
-        return value.toString();
-      }
-      return value;
-    }));
-
     const signature = await this.signer.signTypedData(
       domain,
       PAYMENT_PERMIT_TYPES,
       permitForSigning as unknown as Record<string, unknown>,
       PAYMENT_PERMIT_PRIMARY_TYPE
     );
-
-    console.log('[SIGN] Signature:', signature);
 
     return {
       x402Version: 2,

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/facilitator.ts
@@ -1,0 +1,37 @@
+import {
+  BaseExactPermitFacilitatorMechanism,
+  type BaseExactPermitFee,
+} from '../../_exact_permit_base/facilitator.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+} from '../../../types/index.js';
+
+/**
+ * BSC / EVM facilitator mechanism for the `exact_permit` scheme.
+ *
+ * Mirrors Python `mechanisms.evm.exact_permit.facilitator.ExactPermitEvmFacilitatorMechanism`.
+ */
+export class ExactPermitEvmFacilitatorMechanism extends BaseExactPermitFacilitatorMechanism {
+  constructor(fee: BaseExactPermitFee) {
+    super(fee);
+  }
+
+  /**
+   * Submit `permit` + `transferFrom` on-chain via the PaymentPermit contract.
+   *
+   * TODO(v0.6.0b): wire viem WalletClient and call PaymentPermit
+   * `permitTransferFrom`.
+   */
+  async settle(
+    _payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return {
+      success: false,
+      network: requirements.network,
+      errorReason: 'evm_exact_permit_settle_not_implemented',
+    };
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/facilitator.ts
@@ -1,37 +1,77 @@
+/**
+ * EVM facilitator mechanism for the `exact_permit` scheme.
+ *
+ * Mirrors Python `mechanisms.evm.exact_permit.facilitator.ExactPermitEvmFacilitatorMechanism`.
+ *
+ * Settles by calling `PaymentPermit.permitTransferFrom(permit, owner, signature)`
+ * via the facilitator's EVM signer (viem).
+ */
+
 import {
   BaseExactPermitFacilitatorMechanism,
   type BaseExactPermitFee,
 } from '../../_exact_permit_base/facilitator.js';
 import type {
-  PaymentPayload,
+  PaymentPermit,
   PaymentRequirements,
-  SettleResponse,
 } from '../../../types/index.js';
+import { FacilitatorSigner } from '../../../signers/facilitator/base.js';
+import { EvmAddressConverter, type AddressConverter } from '../../../address.js';
+import { getPaymentPermitAddress } from '../../../config.js';
+import { KIND_MAP, PAYMENT_PERMIT_ABI } from '../../../abi.js';
 
-/**
- * BSC / EVM facilitator mechanism for the `exact_permit` scheme.
- *
- * Mirrors Python `mechanisms.evm.exact_permit.facilitator.ExactPermitEvmFacilitatorMechanism`.
- */
 export class ExactPermitEvmFacilitatorMechanism extends BaseExactPermitFacilitatorMechanism {
-  constructor(fee: BaseExactPermitFee) {
-    super(fee);
+  constructor(signer: FacilitatorSigner, fee: BaseExactPermitFee = {}) {
+    super(signer, fee);
+  }
+
+  protected getAddressConverter(): AddressConverter {
+    return new EvmAddressConverter();
   }
 
   /**
-   * Submit `permit` + `transferFrom` on-chain via the PaymentPermit contract.
-   *
-   * TODO(v0.6.0b): wire viem WalletClient and call PaymentPermit
-   * `permitTransferFrom`.
+   * Build the permit struct in viem's expected object shape and call
+   * `permitTransferFrom` via the facilitator's EVM signer.
    */
-  async settle(
-    _payload: PaymentPayload,
+  protected async settlePaymentOnly(
+    permit: PaymentPermit,
+    signature: string,
     requirements: PaymentRequirements,
-  ): Promise<SettleResponse> {
-    return {
-      success: false,
-      network: requirements.network,
-      errorReason: 'evm_exact_permit_settle_not_implemented',
+  ): Promise<string | null> {
+    const contractAddress = getPaymentPermitAddress(requirements.network);
+    const norm = (s: string) => this.addressConverter.toEvmFormat(s);
+
+    // viem `encodeFunctionData` accepts objects mirroring the ABI tuple components.
+    const permitArg = {
+      meta: {
+        kind: KIND_MAP[permit.meta.kind],
+        paymentId: permit.meta.paymentId as `0x${string}`,
+        nonce: BigInt(permit.meta.nonce),
+        validAfter: BigInt(permit.meta.validAfter),
+        validBefore: BigInt(permit.meta.validBefore),
+      },
+      buyer: norm(permit.buyer),
+      caller: norm(permit.caller),
+      payment: {
+        payToken: norm(permit.payment.payToken),
+        payAmount: BigInt(permit.payment.payAmount),
+        payTo: norm(permit.payment.payTo),
+      },
+      fee: {
+        feeTo: norm(permit.fee.feeTo),
+        feeAmount: BigInt(permit.fee.feeAmount),
+      },
     };
+
+    const owner = norm(permit.buyer);
+    const sigHex = signature.startsWith('0x') ? signature : `0x${signature}`;
+
+    return this.signer.writeContract(
+      contractAddress,
+      PAYMENT_PERMIT_ABI as unknown as unknown[],
+      'permitTransferFrom',
+      [permitArg, owner, sigHex],
+      requirements.network,
+    );
   }
 }

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/index.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/index.ts
@@ -1,1 +1,3 @@
 export { ExactPermitEvmClientMechanism } from './client.js';
+export { ExactPermitEvmServerMechanism } from './server.js';
+export { ExactPermitEvmFacilitatorMechanism } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/index.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/index.ts
@@ -1,0 +1,1 @@
+export { ExactPermitEvmClientMechanism } from './client.js';

--- a/typescript/packages/x402/src/mechanisms/evm/exact_permit/server.ts
+++ b/typescript/packages/x402/src/mechanisms/evm/exact_permit/server.ts
@@ -1,0 +1,18 @@
+import { isAddress } from 'viem';
+
+import { BaseExactPermitServerMechanism } from '../../_exact_permit_base/server.js';
+
+/**
+ * BSC / EVM server mechanism for the `exact_permit` scheme.
+ *
+ * Mirrors Python `mechanisms.evm.exact_permit.server.ExactPermitEvmServerMechanism`.
+ */
+export class ExactPermitEvmServerMechanism extends BaseExactPermitServerMechanism {
+  protected getNetworkPrefix(): string {
+    return 'eip155:';
+  }
+
+  protected validateAddressFormat(address: string): boolean {
+    return isAddress(address, { strict: false });
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/index.ts
+++ b/typescript/packages/x402/src/mechanisms/index.ts
@@ -25,7 +25,7 @@ export { ExactPermitEvmFacilitatorMechanism } from './evm/exact_permit/index.js'
 export { ExactTronFacilitatorMechanism } from './tron/exact/index.js';
 export { ExactPermitTronFacilitatorMechanism } from './tron/exact_permit/index.js';
 export { ExactGasFreeFacilitatorMechanism } from './tron/exact_gasfree/index.js';
-export type { ExactGasFreeFee } from './tron/exact_gasfree/index.js';
+export type { ExactGasFreeFacilitatorOptions } from './tron/exact_gasfree/index.js';
 
 // === Shared base classes (for users wanting to subclass) ===
 export {

--- a/typescript/packages/x402/src/mechanisms/index.ts
+++ b/typescript/packages/x402/src/mechanisms/index.ts
@@ -1,20 +1,22 @@
 /**
- * x402 Client Mechanisms
+ * Mechanism registry — public API.
+ *
+ * Layout mirrors Python `bankofai.x402.mechanisms` (per-chain subdirs, with
+ * `_base` / `_exact_base` / `_exact_permit_base` holding shared logic).
+ *
+ * Top-level re-exports preserved for back-compat with existing consumers.
  */
 
-// exact_permit scheme
-export { ExactPermitTronClientMechanism } from './exact.js';
-export { ExactPermitEvmClientMechanism } from './exactEvm.js';
+// === Per-(chain, scheme) client mechanisms ===
+export { ExactEvmClientMechanism } from './evm/exact/index.js';
+export { ExactPermitEvmClientMechanism } from './evm/exact_permit/index.js';
+export { ExactTronClientMechanism } from './tron/exact/index.js';
+export { ExactPermitTronClientMechanism } from './tron/exact_permit/index.js';
+export { ExactGasFreeClientMechanism } from './tron/exact_gasfree/index.js';
 
-// exact scheme
-export { ExactTronClientMechanism } from './nativeExactTron.js';
-export { ExactEvmClientMechanism } from './nativeExactEvm.js';
-
-// exact_gasfree scheme
-export { ExactGasFreeClientMechanism } from './exactGasfree.js';
-
-// exact shared types
+// === Shared exact-scheme primitives (EIP-712 / TIP-712 typed-data) ===
 export {
+  DEFAULT_VALIDITY_SECONDS,
   SCHEME_EXACT,
   TRANSFER_AUTH_EIP712_TYPES,
   TRANSFER_AUTH_PRIMARY_TYPE,
@@ -22,4 +24,14 @@ export {
   buildEip712Message,
   createNonce,
   createValidityWindow,
-} from './nativeExact.js';
+} from './_exact_base/index.js';
+export type { TransferAuthorization } from './_exact_base/index.js';
+
+// === Role interface re-exports (single canonical mechanism-rooted path) ===
+export type {
+  ClientMechanism,
+  ClientSigner,
+  ServerMechanism,
+  FacilitatorMechanism,
+  FacilitatorLogger,
+} from './_base/index.js';

--- a/typescript/packages/x402/src/mechanisms/index.ts
+++ b/typescript/packages/x402/src/mechanisms/index.ts
@@ -3,8 +3,6 @@
  *
  * Layout mirrors Python `bankofai.x402.mechanisms` (per-chain subdirs, with
  * `_base` / `_exact_base` / `_exact_permit_base` holding shared logic).
- *
- * Top-level re-exports preserved for back-compat with existing consumers.
  */
 
 // === Per-(chain, scheme) client mechanisms ===
@@ -13,6 +11,35 @@ export { ExactPermitEvmClientMechanism } from './evm/exact_permit/index.js';
 export { ExactTronClientMechanism } from './tron/exact/index.js';
 export { ExactPermitTronClientMechanism } from './tron/exact_permit/index.js';
 export { ExactGasFreeClientMechanism } from './tron/exact_gasfree/index.js';
+
+// === Per-(chain, scheme) server mechanisms ===
+export { ExactEvmServerMechanism } from './evm/exact/index.js';
+export { ExactPermitEvmServerMechanism } from './evm/exact_permit/index.js';
+export { ExactTronServerMechanism } from './tron/exact/index.js';
+export { ExactPermitTronServerMechanism } from './tron/exact_permit/index.js';
+export { ExactGasFreeServerMechanism } from './tron/exact_gasfree/index.js';
+
+// === Per-(chain, scheme) facilitator mechanisms ===
+export { ExactEvmFacilitatorMechanism } from './evm/exact/index.js';
+export { ExactPermitEvmFacilitatorMechanism } from './evm/exact_permit/index.js';
+export { ExactTronFacilitatorMechanism } from './tron/exact/index.js';
+export { ExactPermitTronFacilitatorMechanism } from './tron/exact_permit/index.js';
+export { ExactGasFreeFacilitatorMechanism } from './tron/exact_gasfree/index.js';
+export type { ExactGasFreeFee } from './tron/exact_gasfree/index.js';
+
+// === Shared base classes (for users wanting to subclass) ===
+export {
+  ExactBaseServerMechanism,
+  ExactBaseFacilitatorMechanism,
+  EvmChainAdapter,
+  TronChainAdapter,
+} from './_exact_base/index.js';
+export type { ChainAdapter } from './_exact_base/index.js';
+export {
+  BaseExactPermitServerMechanism,
+  BaseExactPermitFacilitatorMechanism,
+} from './_exact_permit_base/index.js';
+export type { BaseExactPermitFee } from './_exact_permit_base/index.js';
 
 // === Shared exact-scheme primitives (EIP-712 / TIP-712 typed-data) ===
 export {
@@ -27,7 +54,7 @@ export {
 } from './_exact_base/index.js';
 export type { TransferAuthorization } from './_exact_base/index.js';
 
-// === Role interface re-exports (single canonical mechanism-rooted path) ===
+// === Role interface re-exports ===
 export type {
   ClientMechanism,
   ClientSigner,

--- a/typescript/packages/x402/src/mechanisms/registry.test.ts
+++ b/typescript/packages/x402/src/mechanisms/registry.test.ts
@@ -3,8 +3,7 @@
  *
  * Verifies registration into X402Server / X402Facilitator and the cheap,
  * non-RPC paths (scheme name, feeQuote, parsePrice, validate, structural
- * verify). Chain-RPC integration (signature recovery, settle) is stubbed
- * in v0.6.0 and gets its own tests in v0.6.0b.
+ * verify). Chain-RPC integration is covered in per-mechanism tests.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -24,8 +23,41 @@ import {
   ExactTronFacilitatorMechanism,
   ExactTronServerMechanism,
 } from './index.js';
+import { FacilitatorSigner } from '../signers/facilitator/base.js';
+import { GasFreeAPIClient } from '../utils/gasfree.js';
 
-const FAKE_FEE = { feeTo: 'TFeeAddress', defaultBaseFee: '100' };
+/**
+ * Minimal mock signer that satisfies `FacilitatorSigner`. The registry
+ * tests never reach `verify`/`settle`/`checkBalance` — they only need
+ * `getAddress()` so the mechanism constructor doesn't blow up.
+ */
+class MockSigner extends FacilitatorSigner {
+  constructor(private readonly addr: string) {
+    super();
+  }
+  getAddress(): string {
+    return this.addr;
+  }
+  async verifyTypedData(): Promise<boolean> {
+    return true;
+  }
+  async writeContract(): Promise<string | null> {
+    return null;
+  }
+  async checkBalance(): Promise<bigint> {
+    return BigInt(0);
+  }
+  async waitForTransactionReceipt() {
+    return { hash: '0x', blockNumber: '0', status: 'confirmed' as const };
+  }
+}
+
+const MOCK_TRON_SIGNER = new MockSigner('TFeeAddress');
+const MOCK_EVM_SIGNER = new MockSigner('0xFeeAddress');
+const FAKE_GASFREE_FEE = {
+  clients: { 'tron:nile': new GasFreeAPIClient('https://gasfree.test') },
+  baseFee: { USDT: '100' },
+};
 
 describe('Server mechanisms register into X402Server', () => {
   it('registers all 5 server mechanisms across (chain, scheme)', () => {
@@ -88,11 +120,14 @@ describe('Server mechanisms register into X402Server', () => {
 describe('Facilitator mechanisms register into X402Facilitator', () => {
   it('registers all 5 facilitator mechanisms', () => {
     const fac = new X402Facilitator()
-      .register(['eip155:97'], new ExactEvmFacilitatorMechanism())
-      .register(['eip155:97'], new ExactPermitEvmFacilitatorMechanism(FAKE_FEE))
-      .register(['tron:nile'], new ExactTronFacilitatorMechanism())
-      .register(['tron:nile'], new ExactPermitTronFacilitatorMechanism(FAKE_FEE))
-      .register(['tron:nile'], new ExactGasFreeFacilitatorMechanism(FAKE_FEE));
+      .register(['eip155:97'], new ExactEvmFacilitatorMechanism(MOCK_EVM_SIGNER))
+      .register(['eip155:97'], new ExactPermitEvmFacilitatorMechanism(MOCK_EVM_SIGNER))
+      .register(['tron:nile'], new ExactTronFacilitatorMechanism(MOCK_TRON_SIGNER))
+      .register(['tron:nile'], new ExactPermitTronFacilitatorMechanism(MOCK_TRON_SIGNER))
+      .register(
+        ['tron:nile'],
+        new ExactGasFreeFacilitatorMechanism(MOCK_TRON_SIGNER, FAKE_GASFREE_FEE),
+      );
 
     const supported = fac.supported();
     expect(supported.kinds).toHaveLength(5);
@@ -106,8 +141,8 @@ describe('Facilitator mechanisms register into X402Facilitator', () => {
     ]);
   });
 
-  it('exact feeQuote returns null (no fee for exact scheme)', async () => {
-    const mech = new ExactEvmFacilitatorMechanism();
+  it('exact feeQuote returns a zero-fee quote', async () => {
+    const mech = new ExactEvmFacilitatorMechanism(MOCK_EVM_SIGNER);
     const quote = await mech.feeQuote({
       scheme: 'exact',
       network: 'eip155:97',
@@ -115,13 +150,14 @@ describe('Facilitator mechanisms register into X402Facilitator', () => {
       asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
       payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
     });
-    expect(quote).toBeNull();
+    expect(quote?.fee.feeAmount).toBe('0');
+    expect(quote?.pricing).toBe('flat');
   });
 
-  it('permit feeQuote returns the configured fee', async () => {
-    const mech = new ExactPermitEvmFacilitatorMechanism({
+  it('permit feeQuote returns the configured fee for a known symbol', async () => {
+    const mech = new ExactPermitEvmFacilitatorMechanism(MOCK_EVM_SIGNER, {
       feeTo: '0xFee',
-      defaultBaseFee: '5000',
+      baseFee: { USDT: '5000' },
     });
     const quote = await mech.feeQuote({
       scheme: 'exact_permit',
@@ -132,14 +168,13 @@ describe('Facilitator mechanisms register into X402Facilitator', () => {
     });
     expect(quote?.fee.feeTo).toBe('0xFee');
     expect(quote?.fee.feeAmount).toBe('5000');
-    expect(quote?.pricing).toBe('fixed');
+    expect(quote?.pricing).toBe('flat');
   });
 
-  it('per-token base fee override wins over default', async () => {
-    const mech = new ExactPermitEvmFacilitatorMechanism({
+  it('permit feeQuote returns null for an unknown symbol', async () => {
+    const mech = new ExactPermitEvmFacilitatorMechanism(MOCK_EVM_SIGNER, {
       feeTo: '0xFee',
-      defaultBaseFee: '100',
-      baseFeesByToken: { 'eip155:97:0x337610d27c682e347c9cd60bd4b3b107c9d34ddd': '999' },
+      baseFee: { /* no entries */ },
     });
     const quote = await mech.feeQuote({
       scheme: 'exact_permit',
@@ -148,11 +183,11 @@ describe('Facilitator mechanisms register into X402Facilitator', () => {
       asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
       payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
     });
-    expect(quote?.fee.feeAmount).toBe('999');
+    expect(quote).toBeNull();
   });
 
-  it('settle for stubbed mechanisms returns success:false with TODO marker', async () => {
-    const mech = new ExactEvmFacilitatorMechanism();
+  it('settle returns verify failure when the authorization is invalid', async () => {
+    const mech = new ExactEvmFacilitatorMechanism(MOCK_EVM_SIGNER);
     const result = await mech.settle(
       {
         x402Version: 2,
@@ -168,6 +203,6 @@ describe('Facilitator mechanisms register into X402Facilitator', () => {
       },
     );
     expect(result.success).toBe(false);
-    expect(result.errorReason).toContain('not_implemented');
+    expect(result.errorReason).toBe('amount_mismatch');
   });
 });

--- a/typescript/packages/x402/src/mechanisms/registry.test.ts
+++ b/typescript/packages/x402/src/mechanisms/registry.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Smoke tests for the 10 new server + facilitator mechanism wrappers.
+ *
+ * Verifies registration into X402Server / X402Facilitator and the cheap,
+ * non-RPC paths (scheme name, feeQuote, parsePrice, validate, structural
+ * verify). Chain-RPC integration (signature recovery, settle) is stubbed
+ * in v0.6.0 and gets its own tests in v0.6.0b.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { FacilitatorClient } from '../facilitator/client.js';
+import { X402Facilitator } from '../facilitator/x402Facilitator.js';
+import { X402Server } from '../server/x402Server.js';
+import {
+  ExactEvmFacilitatorMechanism,
+  ExactEvmServerMechanism,
+  ExactGasFreeFacilitatorMechanism,
+  ExactGasFreeServerMechanism,
+  ExactPermitEvmFacilitatorMechanism,
+  ExactPermitEvmServerMechanism,
+  ExactPermitTronFacilitatorMechanism,
+  ExactPermitTronServerMechanism,
+  ExactTronFacilitatorMechanism,
+  ExactTronServerMechanism,
+} from './index.js';
+
+const FAKE_FEE = { feeTo: 'TFeeAddress', defaultBaseFee: '100' };
+
+describe('Server mechanisms register into X402Server', () => {
+  it('registers all 5 server mechanisms across (chain, scheme)', () => {
+    const fac = new FacilitatorClient({ baseUrl: 'https://fac.test' });
+    const server = new X402Server()
+      .register('eip155:97', new ExactEvmServerMechanism())
+      .register('eip155:97', new ExactPermitEvmServerMechanism())
+      .register('tron:nile', new ExactTronServerMechanism())
+      .register('tron:nile', new ExactPermitTronServerMechanism())
+      .register('tron:nile', new ExactGasFreeServerMechanism())
+      .setFacilitator(fac);
+    // Smoke: server is configured without errors.
+    expect(server).toBeInstanceOf(X402Server);
+  });
+
+  it('each server mechanism reports its scheme correctly', () => {
+    expect(new ExactEvmServerMechanism().scheme()).toBe('exact');
+    expect(new ExactPermitEvmServerMechanism().scheme()).toBe('exact_permit');
+    expect(new ExactTronServerMechanism().scheme()).toBe('exact');
+    expect(new ExactPermitTronServerMechanism().scheme()).toBe('exact_permit');
+    expect(new ExactGasFreeServerMechanism().scheme()).toBe('exact_gasfree');
+  });
+
+  it('parsePrice works on all 5 server mechanisms', async () => {
+    const evmExact = await new ExactEvmServerMechanism().parsePrice('1 USDT', 'eip155:97');
+    expect(evmExact.amount).toBe('1000000000000000000'); // 18 decimals
+    const tronExact = await new ExactTronServerMechanism().parsePrice('1 USDT', 'tron:mainnet');
+    expect(tronExact.amount).toBe('1000000'); // 6 decimals
+  });
+
+  it('enhancePaymentRequirements attaches token name', async () => {
+    const mech = new ExactPermitEvmServerMechanism();
+    const enhanced = await mech.enhancePaymentRequirements(
+      {
+        scheme: 'exact_permit',
+        network: 'eip155:97',
+        amount: '1000000',
+        asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
+        payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
+      },
+      'PAYMENT_ONLY',
+    );
+    expect(enhanced.extra?.name).toBe('Tether USD');
+  });
+
+  it('validatePaymentRequirements rejects mismatched network prefix', () => {
+    const evmMech = new ExactPermitEvmServerMechanism();
+    expect(
+      evmMech.validatePaymentRequirements({
+        scheme: 'exact_permit',
+        network: 'tron:nile',
+        amount: '1',
+        asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('Facilitator mechanisms register into X402Facilitator', () => {
+  it('registers all 5 facilitator mechanisms', () => {
+    const fac = new X402Facilitator()
+      .register(['eip155:97'], new ExactEvmFacilitatorMechanism())
+      .register(['eip155:97'], new ExactPermitEvmFacilitatorMechanism(FAKE_FEE))
+      .register(['tron:nile'], new ExactTronFacilitatorMechanism())
+      .register(['tron:nile'], new ExactPermitTronFacilitatorMechanism(FAKE_FEE))
+      .register(['tron:nile'], new ExactGasFreeFacilitatorMechanism(FAKE_FEE));
+
+    const supported = fac.supported();
+    expect(supported.kinds).toHaveLength(5);
+    const schemes = supported.kinds.map((k) => `${k.network}/${k.scheme}`).sort();
+    expect(schemes).toEqual([
+      'eip155:97/exact',
+      'eip155:97/exact_permit',
+      'tron:nile/exact',
+      'tron:nile/exact_gasfree',
+      'tron:nile/exact_permit',
+    ]);
+  });
+
+  it('exact feeQuote returns null (no fee for exact scheme)', async () => {
+    const mech = new ExactEvmFacilitatorMechanism();
+    const quote = await mech.feeQuote({
+      scheme: 'exact',
+      network: 'eip155:97',
+      amount: '1',
+      asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
+      payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
+    });
+    expect(quote).toBeNull();
+  });
+
+  it('permit feeQuote returns the configured fee', async () => {
+    const mech = new ExactPermitEvmFacilitatorMechanism({
+      feeTo: '0xFee',
+      defaultBaseFee: '5000',
+    });
+    const quote = await mech.feeQuote({
+      scheme: 'exact_permit',
+      network: 'eip155:97',
+      amount: '1',
+      asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
+      payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
+    });
+    expect(quote?.fee.feeTo).toBe('0xFee');
+    expect(quote?.fee.feeAmount).toBe('5000');
+    expect(quote?.pricing).toBe('fixed');
+  });
+
+  it('per-token base fee override wins over default', async () => {
+    const mech = new ExactPermitEvmFacilitatorMechanism({
+      feeTo: '0xFee',
+      defaultBaseFee: '100',
+      baseFeesByToken: { 'eip155:97:0x337610d27c682e347c9cd60bd4b3b107c9d34ddd': '999' },
+    });
+    const quote = await mech.feeQuote({
+      scheme: 'exact_permit',
+      network: 'eip155:97',
+      amount: '1',
+      asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
+      payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
+    });
+    expect(quote?.fee.feeAmount).toBe('999');
+  });
+
+  it('settle for stubbed mechanisms returns success:false with TODO marker', async () => {
+    const mech = new ExactEvmFacilitatorMechanism();
+    const result = await mech.settle(
+      {
+        x402Version: 2,
+        accepted: {} as never,
+        payload: { signature: '0x', authorization: { from: '', to: '', value: '0', validAfter: '0', validBefore: '0', nonce: '0x' } },
+      },
+      {
+        scheme: 'exact',
+        network: 'eip155:97',
+        amount: '1',
+        asset: '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd',
+        payTo: '0x1825bB32db3443dEc2cc7508b2D818fc13EaD878',
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toContain('not_implemented');
+  });
+});

--- a/typescript/packages/x402/src/mechanisms/tron/exact/client.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact/client.ts
@@ -1,8 +1,8 @@
 /**
- * ExactEvmClientMechanism - EVM client mechanism for "exact" payment scheme
+ * ExactTronClientMechanism - TRON client mechanism for "exact" payment scheme
  *
- * Uses ERC-3009 TransferWithAuthorization with EIP-712 signing.
- * EVM addresses are used directly without conversion.
+ * Uses ERC-3009 TransferWithAuthorization with TIP-712 signing.
+ * Addresses are converted from TRON Base58 to EVM hex for signing.
  */
 
 import type {
@@ -10,12 +10,12 @@ import type {
   ClientSigner,
   PaymentRequirements,
   PaymentPayload,
-} from '../index.js';
+} from '../../../index.js';
 import {
   getChainId,
-  EvmAddressConverter,
-} from '../index.js';
-import { findByAddress } from '../tokens.js';
+  TronAddressConverter,
+} from '../../../index.js';
+import { findByAddress } from '../../../tokens.js';
 import {
   SCHEME_EXACT,
   TRANSFER_AUTH_EIP712_TYPES,
@@ -24,15 +24,15 @@ import {
   buildEip712Message,
   createNonce,
   createValidityWindow,
-} from './nativeExact.js';
-import type { TransferAuthorization } from './nativeExact.js';
+} from '../../_exact_base/types.js';
+import type { TransferAuthorization } from '../../_exact_base/types.js';
 
 /**
- * EVM client mechanism for "exact" payment scheme
+ * TRON client mechanism for "exact" payment scheme
  */
-export class ExactEvmClientMechanism implements ClientMechanism {
+export class ExactTronClientMechanism implements ClientMechanism {
   private signer: ClientSigner;
-  private addressConverter = new EvmAddressConverter();
+  private addressConverter = new TronAddressConverter();
 
   constructor(signer: ClientSigner) {
     this.signer = signer;

--- a/typescript/packages/x402/src/mechanisms/tron/exact/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact/facilitator.ts
@@ -1,34 +1,69 @@
+/**
+ * TRON facilitator mechanism for the `exact` (ERC-3009) scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact.facilitator.ExactTronFacilitatorMechanism`.
+ *
+ * Settles by calling `transferWithAuthorization(from, to, value, validAfter,
+ * validBefore, nonce, v, r, s)` directly on the TRC20 token contract via the
+ * facilitator's TRON signer.
+ */
+
 import { ExactBaseFacilitatorMechanism } from '../../_exact_base/facilitator.js';
 import { TronChainAdapter } from '../../_exact_base/tronAdapter.js';
 import type {
-  PaymentPayload,
   PaymentRequirements,
-  SettleResponse,
+  TransferAuthorization,
 } from '../../../types/index.js';
+import { FacilitatorSigner } from '../../../signers/facilitator/base.js';
+import { TRANSFER_WITH_AUTHORIZATION_ABI } from '../../../abi.js';
 
 /**
- * TRON facilitator mechanism for the `exact` scheme.
- *
- * Mirrors Python `mechanisms.tron.exact.facilitator.ExactTronFacilitatorMechanism`.
+ * Function selector for tronweb's `triggerSmartContract`.
+ * Must match the on-chain ABI exactly.
  */
+const TRANSFER_WITH_AUTH_SELECTOR =
+  'transferWithAuthorization(' +
+  'address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32' +
+  ')';
+
 export class ExactTronFacilitatorMechanism extends ExactBaseFacilitatorMechanism {
-  constructor() {
-    super(new TronChainAdapter());
+  constructor(
+    signer: FacilitatorSigner,
+    options: { allowedTokens?: ReadonlyArray<string> } = {},
+  ) {
+    super(signer, new TronChainAdapter(), options);
   }
 
-  /**
-   * Settle the authorization on TRON by calling `transferWithAuthorization`.
-   *
-   * TODO(v0.6.0b): wire tronweb / @bankofai/agent-wallet TRON broadcasting.
-   */
-  async settle(
-    _payload: PaymentPayload,
+  protected async settlePaymentOnly(
+    auth: TransferAuthorization,
+    signature: string,
     requirements: PaymentRequirements,
-  ): Promise<SettleResponse> {
-    return {
-      success: false,
-      network: requirements.network,
-      errorReason: 'tron_exact_settle_not_implemented',
-    };
+  ): Promise<string | null> {
+    const adapter = this.adapter;
+    const { v, r, s } = this.splitSignature(signature);
+
+    // tronweb's triggerSmartContract expects address values as 0x EVM hex.
+    const args = [
+      { type: 'address', value: adapter.toSigningAddress(auth.from) },
+      { type: 'address', value: adapter.toSigningAddress(auth.to) },
+      { type: 'uint256', value: auth.value },
+      { type: 'uint256', value: String(auth.validAfter) },
+      { type: 'uint256', value: String(auth.validBefore) },
+      {
+        type: 'bytes32',
+        value: auth.nonce.startsWith('0x') ? auth.nonce : `0x${auth.nonce}`,
+      },
+      { type: 'uint8', value: v },
+      { type: 'bytes32', value: r },
+      { type: 'bytes32', value: s },
+    ];
+
+    return this.signer.writeContract(
+      requirements.asset, // TRC20 token is the verifying contract
+      TRANSFER_WITH_AUTHORIZATION_ABI as unknown as unknown[],
+      TRANSFER_WITH_AUTH_SELECTOR,
+      args,
+      requirements.network,
+    );
   }
 }

--- a/typescript/packages/x402/src/mechanisms/tron/exact/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact/facilitator.ts
@@ -1,0 +1,34 @@
+import { ExactBaseFacilitatorMechanism } from '../../_exact_base/facilitator.js';
+import { TronChainAdapter } from '../../_exact_base/tronAdapter.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+} from '../../../types/index.js';
+
+/**
+ * TRON facilitator mechanism for the `exact` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact.facilitator.ExactTronFacilitatorMechanism`.
+ */
+export class ExactTronFacilitatorMechanism extends ExactBaseFacilitatorMechanism {
+  constructor() {
+    super(new TronChainAdapter());
+  }
+
+  /**
+   * Settle the authorization on TRON by calling `transferWithAuthorization`.
+   *
+   * TODO(v0.6.0b): wire tronweb / @bankofai/agent-wallet TRON broadcasting.
+   */
+  async settle(
+    _payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return {
+      success: false,
+      network: requirements.network,
+      errorReason: 'tron_exact_settle_not_implemented',
+    };
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/tron/exact/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact/index.ts
@@ -1,1 +1,3 @@
 export { ExactTronClientMechanism } from './client.js';
+export { ExactTronServerMechanism } from './server.js';
+export { ExactTronFacilitatorMechanism } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact/index.ts
@@ -1,0 +1,1 @@
+export { ExactTronClientMechanism } from './client.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact/server.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact/server.ts
@@ -1,0 +1,28 @@
+import { ExactBaseServerMechanism } from '../../_exact_base/server.js';
+import { TronChainAdapter } from '../../_exact_base/tronAdapter.js';
+import type { PaymentPermit } from '../../../types/index.js';
+
+/**
+ * TRON server mechanism for the `exact` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact.server.ExactTronServerMechanism`.
+ */
+export class ExactTronServerMechanism extends ExactBaseServerMechanism {
+  constructor() {
+    super(new TronChainAdapter());
+  }
+
+  /**
+   * TRON TIP-712 signature verification for ERC-3009 authorizations.
+   *
+   * TODO(v0.6.0b): port TIP-712 signature recovery from Python. Returns
+   * `true` for now — facilitator side does the authoritative check.
+   */
+  async verifySignature(
+    _permit: PaymentPermit | null | undefined,
+    _signature: string,
+    _network: string,
+  ): Promise<boolean> {
+    return true;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/client.test.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ExactGasFreeClientMechanism } from './exactGasfree.js';
-import { GasFreeAPIClient } from '../utils/gasfree.js';
-import { PaymentRequirements, ClientSigner } from '../index.js';
+import { ExactGasFreeClientMechanism } from './client.js';
+import { GasFreeAPIClient } from '../../../utils/gasfree.js';
+import { PaymentRequirements, ClientSigner } from '../../../index.js';
 
 const assembleGasFreeTransactionJson = vi.fn((params: any) => ({
   domain: {
@@ -38,7 +38,7 @@ vi.mock('@gasfree/gasfree-sdk', () => {
   };
 });
 
-vi.mock('../utils/gasfree.js', () => {
+vi.mock('../../../utils/gasfree.js', () => {
   return {
     GasFreeAPIClient: vi.fn().mockImplementation(() => {
       return {

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/client.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/client.ts
@@ -10,10 +10,10 @@ import {
   GASFREE_PRIMARY_TYPE,
   getChainId,
   UnsupportedNetworkError,
-} from '../index.js';
-import { GASFREE_TYPES, GasFreeAPIClient, type GasFreeAddressInfo } from '../utils/gasfree.js';
-import { findByAddress } from '../tokens.js';
-import { TronAddressConverter, ZERO_ADDRESS_HEX } from '../address.js';
+} from '../../../index.js';
+import { GASFREE_TYPES, GasFreeAPIClient, type GasFreeAddressInfo } from '../../../utils/gasfree.js';
+import { findByAddress } from '../../../tokens.js';
+import { TronAddressConverter, ZERO_ADDRESS_HEX } from '../../../address.js';
 
 function requireEvmAddress(
   raw: unknown,

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/facilitator.test.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/facilitator.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import { FacilitatorSigner } from '../../../signers/facilitator/base.js';
+import type { PaymentPayload, PaymentRequirements } from '../../../types/index.js';
+import {
+  GasFreeAPIClient,
+  type GasFreeProvider,
+  type GasFreeSubmitResponseData,
+} from '../../../utils/gasfree.js';
+import { ExactGasFreeFacilitatorMechanism } from './facilitator.js';
+
+class MockSigner extends FacilitatorSigner {
+  public verifiedMessage: Record<string, unknown> | null = null;
+
+  getAddress(): string {
+    return 'TFeeAddress';
+  }
+
+  async verifyTypedData(
+    _address: string,
+    _domain: Record<string, unknown>,
+    _types: Record<string, ReadonlyArray<{ name: string; type: string }>>,
+    message: Record<string, unknown>,
+  ): Promise<boolean> {
+    this.verifiedMessage = message;
+    return true;
+  }
+
+  async writeContract(): Promise<string | null> {
+    return null;
+  }
+
+  async checkBalance(): Promise<bigint> {
+    return BigInt(2_000_000);
+  }
+
+  async waitForTransactionReceipt() {
+    return { hash: '0x', blockNumber: '0', status: 'confirmed' as const };
+  }
+}
+
+class MockGasFreeClient extends GasFreeAPIClient {
+  public submittedMessage: Record<string, unknown> | null = null;
+
+  constructor(private readonly providers: GasFreeProvider[]) {
+    super('https://gasfree.test');
+  }
+
+  async getProviders(): Promise<GasFreeProvider[]> {
+    return this.providers;
+  }
+
+  async submit(
+    _domain: unknown,
+    message: Record<string, unknown>,
+    _signature: string,
+  ): Promise<string> {
+    this.submittedMessage = message;
+    return 'trace-123';
+  }
+
+  async waitForSuccess(_traceId: string): Promise<GasFreeSubmitResponseData> {
+    return {
+      id: 'trace-123',
+      state: 'SUCCEED',
+      createdAt: new Date().toISOString(),
+      accountAddress: BUYER,
+      gasFreeAddress: GASFREE_ADDRESS,
+      providerAddress: PROVIDER,
+      targetAddress: PAY_TO,
+      nonce: 7,
+      tokenAddress: TOKEN,
+      amount: '1000000',
+      expiredAt: new Date(Date.now() + 60_000).toISOString(),
+      txnHash: 'tron-tx-hash',
+      txnState: 'ON_CHAIN',
+    };
+  }
+}
+
+const TOKEN = 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf';
+const PROVIDER = 'TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC';
+const BUYER = 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx';
+const PAY_TO = 'TT8rEWbCoNX7vpEUauxb7rWJsTgs8vDLAn';
+const GASFREE_ADDRESS = 'TQghdCeVDA6CnuNVTUhfaAyPfTetqZWNpm';
+
+const provider: GasFreeProvider = {
+  address: PROVIDER,
+  name: 'Provider',
+  icon: '',
+  website: '',
+  config: {
+    maxPendingTransfer: 10,
+    minDeadlineDuration: 60,
+    maxDeadlineDuration: 3600,
+    defaultDeadlineDuration: 600,
+  },
+};
+
+function makeRequirements(): PaymentRequirements {
+  return {
+    scheme: 'exact_gasfree',
+    network: 'tron:nile',
+    amount: '1000000',
+    asset: TOKEN,
+    payTo: PAY_TO,
+  };
+}
+
+function makePayload(): PaymentPayload {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    x402Version: 2,
+    accepted: makeRequirements(),
+    payload: {
+      signature: '0x' + '11'.repeat(65),
+      paymentPermit: {
+        meta: {
+          kind: 'PAYMENT_ONLY',
+          paymentId: '0x' + '12'.repeat(16),
+          nonce: '7',
+          validAfter: 0,
+          validBefore: now + 600,
+        },
+        buyer: BUYER,
+        caller: PROVIDER,
+        payment: {
+          payToken: TOKEN,
+          payAmount: '1000000',
+          payTo: PAY_TO,
+        },
+        fee: {
+          feeTo: PROVIDER,
+          feeAmount: '100000',
+        },
+      },
+    },
+    extensions: { gasfreeAddress: GASFREE_ADDRESS },
+  };
+}
+
+function makeMechanism(client: MockGasFreeClient, signer = new MockSigner()) {
+  return {
+    signer,
+    mechanism: new ExactGasFreeFacilitatorMechanism(signer, {
+      clients: { 'tron:nile': client },
+      baseFee: { USDT: '100000' },
+    }),
+  };
+}
+
+describe('ExactGasFreeFacilitatorMechanism', () => {
+  it('returns provider-backed flat fee quotes', async () => {
+    const client = new MockGasFreeClient([provider]);
+    const { mechanism } = makeMechanism(client);
+
+    const quote = await mechanism.feeQuote(makeRequirements());
+
+    expect(quote?.fee).toMatchObject({
+      feeTo: PROVIDER,
+      feeAmount: '100000',
+      caller: PROVIDER,
+    });
+    expect(quote?.pricing).toBe('flat');
+  });
+
+  it('verifies GasFree permits with TIP-712 fields', async () => {
+    const client = new MockGasFreeClient([provider]);
+    const { mechanism, signer } = makeMechanism(client);
+
+    const result = await mechanism.verify(makePayload(), makeRequirements());
+
+    expect(result).toEqual({ isValid: true });
+    expect(signer.verifiedMessage).toMatchObject({
+      value: BigInt(1000000),
+      maxFee: BigInt(100000),
+      nonce: BigInt(7),
+      version: BigInt(1),
+    });
+  });
+
+  it('settles through GasFree API and returns the TRON transaction hash', async () => {
+    const client = new MockGasFreeClient([provider]);
+    const { mechanism } = makeMechanism(client);
+
+    const result = await mechanism.settle(makePayload(), makeRequirements());
+
+    expect(result).toEqual({
+      success: true,
+      transaction: 'tron-tx-hash',
+      network: 'tron:nile',
+    });
+    expect(client.submittedMessage).toMatchObject({
+      token: TOKEN,
+      serviceProvider: PROVIDER,
+      user: BUYER,
+      receiver: PAY_TO,
+      value: '1000000',
+      maxFee: '100000',
+      nonce: 7,
+    });
+  });
+});

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/facilitator.ts
@@ -1,64 +1,92 @@
-import type { FacilitatorMechanism } from '../../../facilitator/x402Facilitator.js';
+/**
+ * TRON facilitator mechanism for the `exact_gasfree` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact_gasfree.facilitator`.
+ * The buyer signs the GasFree TIP-712 permit, and the facilitator submits it
+ * through the configured GasFree API proxy.
+ */
+
+import {
+  BaseExactPermitFacilitatorMechanism,
+  type BaseExactPermitFee,
+} from '../../_exact_permit_base/facilitator.js';
 import type {
   FeeQuoteResponse,
+  PaymentPermit,
   PaymentPayload,
   PaymentRequirements,
   SettleResponse,
   VerifyResponse,
 } from '../../../types/index.js';
+import { FacilitatorSigner } from '../../../signers/facilitator/base.js';
+import { TronAddressConverter, type AddressConverter } from '../../../address.js';
+import {
+  GASFREE_TYPES,
+  GasFreeAPIClient,
+  type GasFreeProvider,
+  getGasFreeDomain,
+} from '../../../utils/gasfree.js';
+import { GASFREE_PRIMARY_TYPE } from '../../../abi.js';
 
 const SCHEME_EXACT_GASFREE = 'exact_gasfree';
+const FEE_QUOTE_EXPIRY_SECONDS = 300;
 
-/** Config for {@link ExactGasFreeFacilitatorMechanism}. */
-export interface ExactGasFreeFee {
-  /** Recipient address that collects the facilitator fee (TRON Base58 or hex). */
-  feeTo: string;
-  /** Optional caller address bound on-chain. */
-  caller?: string;
-  /** Per-token base fee (smallest unit, decimal string). Key = `${network}:${tokenAddress}`. */
-  baseFeesByToken?: Record<string, string>;
-  /** Fallback fee when no per-token entry matches. */
-  defaultBaseFee?: string;
+export interface ExactGasFreeFacilitatorOptions extends BaseExactPermitFee {
+  clients: Record<string, GasFreeAPIClient>;
 }
 
-/**
- * TRON facilitator mechanism for the `exact_gasfree` scheme.
- *
- * Mirrors Python `mechanisms.tron.exact_gasfree.facilitator.ExactGasFreeFacilitatorMechanism`.
- * Uses TRON GasFree (custodial relayer) — user signs TIP-712 permit, the
- * service provider submits the transaction on-chain.
- */
-export class ExactGasFreeFacilitatorMechanism implements FacilitatorMechanism {
-  constructor(private readonly fee: ExactGasFreeFee) {}
+export class ExactGasFreeFacilitatorMechanism extends BaseExactPermitFacilitatorMechanism {
+  private readonly clients: Record<string, GasFreeAPIClient>;
+
+  constructor(
+    signer: FacilitatorSigner,
+    options: ExactGasFreeFacilitatorOptions,
+  ) {
+    super(signer, options);
+    this.clients = options.clients;
+  }
 
   scheme(): string {
     return SCHEME_EXACT_GASFREE;
+  }
+
+  protected getAddressConverter(): AddressConverter {
+    return new TronAddressConverter();
+  }
+
+  private getApiClient(network: string): GasFreeAPIClient {
+    const client = this.clients[network];
+    if (!client) {
+      throw new Error(`GasFree is not configured for network: ${network}`);
+    }
+    return client;
   }
 
   async feeQuote(
     accept: PaymentRequirements,
     _context?: Record<string, unknown>,
   ): Promise<FeeQuoteResponse | null> {
-    const key = `${accept.network}:${accept.asset.toLowerCase()}`;
-    const feeAmount =
-      this.fee.baseFeesByToken?.[key] ?? this.fee.defaultBaseFee ?? '0';
+    const baseFee = this.getBaseFee(accept.asset, accept.network);
+    if (baseFee === null) return null;
+
+    const providers = await this.getApiClient(accept.network).getProviders();
+    if (providers.length === 0) return null;
+
+    const selected = providers[Math.floor(Math.random() * providers.length)]!;
     return {
       fee: {
-        feeTo: this.fee.feeTo,
-        feeAmount,
-        ...(this.fee.caller ? { caller: this.fee.caller } : {}),
+        feeTo: selected.address,
+        feeAmount: baseFee.toString(),
+        caller: selected.address,
       },
-      pricing: 'fixed',
-      scheme: this.scheme(),
+      pricing: 'flat',
+      scheme: accept.scheme,
       network: accept.network,
       asset: accept.asset,
-    };
+      expiresAt: Math.floor(Date.now() / 1000) + FEE_QUOTE_EXPIRY_SECONDS,
+    } as FeeQuoteResponse;
   }
 
-  /**
-   * Off-chain verify: structural checks. Real TIP-712 signature + GasFree
-   * API deadline-clamping checks left as TODO.
-   */
   async verify(
     payload: PaymentPayload,
     requirements: PaymentRequirements,
@@ -67,36 +95,216 @@ export class ExactGasFreeFacilitatorMechanism implements FacilitatorMechanism {
     if (!permit) {
       return { isValid: false, invalidReason: 'missing_permit' };
     }
-    if (permit.payment.payToken !== requirements.asset) {
-      return { isValid: false, invalidReason: 'asset_mismatch' };
+
+    const validationError = await this.validateGasFreePermit(permit, requirements);
+    if (validationError) {
+      return { isValid: false, invalidReason: validationError };
     }
-    if (permit.payment.payTo !== requirements.payTo) {
-      return { isValid: false, invalidReason: 'payTo_mismatch' };
+
+    const validSig = await this.verifyGasFreeSignature(
+      permit,
+      payload.payload.signature,
+      requirements.network,
+    );
+    if (!validSig) {
+      return { isValid: false, invalidReason: 'invalid_signature' };
     }
-    try {
-      if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) {
-        return { isValid: false, invalidReason: 'amount_too_low' };
-      }
-    } catch {
-      return { isValid: false, invalidReason: 'invalid_amount' };
-    }
-    // TODO(v0.6.0b): TIP-712 signature recovery + GasFree balance/deadline check.
+
     return { isValid: true };
   }
 
-  /**
-   * Submit the GasFree permit through the GasFreeController contract.
-   *
-   * TODO(v0.6.0b): call GasFree relayer API or contract directly.
-   */
   async settle(
-    _payload: PaymentPayload,
+    payload: PaymentPayload,
     requirements: PaymentRequirements,
   ): Promise<SettleResponse> {
-    return {
-      success: false,
-      network: requirements.network,
-      errorReason: 'tron_exact_gasfree_settle_not_implemented',
+    const verifyResult = await this.verify(payload, requirements);
+    if (!verifyResult.isValid) {
+      return {
+        success: false,
+        errorReason: verifyResult.invalidReason ?? 'verification_failed',
+        network: requirements.network,
+      };
+    }
+
+    const permit = payload.payload.paymentPermit;
+    const signature = payload.payload.signature;
+    const gasfreeAddress = payload.extensions?.gasfreeAddress;
+    if (!permit || !signature || typeof gasfreeAddress !== 'string') {
+      return {
+        success: false,
+        errorReason: 'missing_payload_data',
+        network: requirements.network,
+      };
+    }
+
+    try {
+      const balance = await this.signer.checkBalance(
+        requirements.asset,
+        requirements.network,
+        gasfreeAddress,
+      );
+      const requiredTotal =
+        BigInt(requirements.amount) + BigInt(permit.fee.feeAmount);
+      if (balance < requiredTotal) {
+        return {
+          success: false,
+          errorReason: `insufficient balance in gasfree wallet ${gasfreeAddress}`,
+          network: requirements.network,
+        };
+      }
+    } catch {
+      // Python treats this as a best-effort preflight; submission can still fail
+      // with the relayer's exact reason.
+    }
+
+    const client = this.getApiClient(requirements.network);
+    try {
+      const traceId = await this.settlePaymentOnly(
+        permit,
+        signature,
+        requirements,
+      );
+      if (!traceId) {
+        return {
+          success: false,
+          errorReason: 'api_no_response',
+          network: requirements.network,
+        };
+      }
+
+      const result = await client.waitForSuccess(traceId);
+      if (!result.txnHash) {
+        return {
+          success: false,
+          errorReason: 'missing_transaction_hash',
+          network: requirements.network,
+        };
+      }
+
+      return {
+        success: true,
+        transaction: result.txnHash,
+        network: requirements.network,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        errorReason: err instanceof Error ? err.message : String(err),
+        network: requirements.network,
+      };
+    }
+  }
+
+  private async validateGasFreePermit(
+    permit: PaymentPermit,
+    requirements: PaymentRequirements,
+  ): Promise<string | null> {
+    const norm = (s: string) => this.addressConverter.normalize(s);
+
+    if (
+      this.allowedTokens !== null &&
+      !this.allowedTokens.has(norm(permit.payment.payToken))
+    ) {
+      return 'token_not_allowed';
+    }
+
+    if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) {
+      return 'amount_mismatch';
+    }
+    if (norm(permit.payment.payToken) !== norm(requirements.asset)) {
+      return 'token_mismatch';
+    }
+    if (norm(permit.payment.payTo) !== norm(requirements.payTo)) {
+      return 'payto_mismatch';
+    }
+
+    let providers: GasFreeProvider[];
+    try {
+      providers = await this.getApiClient(requirements.network).getProviders();
+    } catch {
+      if (norm(permit.fee.feeTo) !== norm(this.feeTo)) {
+        return 'fee_to_mismatch';
+      }
+      providers = [];
+    }
+
+    if (providers.length > 0) {
+      const allowedProviders = new Set(providers.map((p) => norm(p.address)));
+      if (!allowedProviders.has(norm(permit.fee.feeTo))) {
+        return 'fee_to_mismatch';
+      }
+    }
+
+    const expectedFee = this.getBaseFee(
+      permit.payment.payToken,
+      requirements.network,
+    );
+    if (expectedFee === null) {
+      return 'unsupported_token';
+    }
+    if (BigInt(permit.fee.feeAmount) < expectedFee) {
+      return 'fee_amount_mismatch';
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (permit.meta.validBefore < now) {
+      return 'expired';
+    }
+    return null;
+  }
+
+  private async verifyGasFreeSignature(
+    permit: PaymentPermit,
+    signature: string,
+    network: string,
+  ): Promise<boolean> {
+    const converter = this.addressConverter;
+    const message: Record<string, unknown> = {
+      token: converter.toEvmFormat(permit.payment.payToken),
+      serviceProvider: converter.toEvmFormat(permit.fee.feeTo),
+      user: converter.toEvmFormat(permit.buyer),
+      receiver: converter.toEvmFormat(permit.payment.payTo),
+      value: BigInt(permit.payment.payAmount),
+      maxFee: BigInt(permit.fee.feeAmount),
+      deadline: BigInt(permit.meta.validBefore),
+      version: BigInt(1),
+      nonce: BigInt(permit.meta.nonce),
     };
+
+    return this.signer.verifyTypedData(
+      permit.buyer,
+      getGasFreeDomain(network),
+      GASFREE_TYPES as unknown as Record<
+        string,
+        ReadonlyArray<{ name: string; type: string }>
+      >,
+      message,
+      signature,
+      GASFREE_PRIMARY_TYPE,
+    );
+  }
+
+  protected async settlePaymentOnly(
+    permit: PaymentPermit,
+    signature: string,
+    requirements: PaymentRequirements,
+  ): Promise<string | null> {
+    const message = {
+      token: permit.payment.payToken,
+      serviceProvider: permit.fee.feeTo,
+      user: permit.buyer,
+      receiver: permit.payment.payTo,
+      value: permit.payment.payAmount,
+      maxFee: permit.fee.feeAmount,
+      deadline: permit.meta.validBefore,
+      version: 1,
+      nonce: Number(permit.meta.nonce),
+    };
+
+    return this.getApiClient(requirements.network).submit(
+      getGasFreeDomain(requirements.network),
+      message,
+      signature,
+    );
   }
 }

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/facilitator.ts
@@ -1,0 +1,102 @@
+import type { FacilitatorMechanism } from '../../../facilitator/x402Facilitator.js';
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../../../types/index.js';
+
+const SCHEME_EXACT_GASFREE = 'exact_gasfree';
+
+/** Config for {@link ExactGasFreeFacilitatorMechanism}. */
+export interface ExactGasFreeFee {
+  /** Recipient address that collects the facilitator fee (TRON Base58 or hex). */
+  feeTo: string;
+  /** Optional caller address bound on-chain. */
+  caller?: string;
+  /** Per-token base fee (smallest unit, decimal string). Key = `${network}:${tokenAddress}`. */
+  baseFeesByToken?: Record<string, string>;
+  /** Fallback fee when no per-token entry matches. */
+  defaultBaseFee?: string;
+}
+
+/**
+ * TRON facilitator mechanism for the `exact_gasfree` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact_gasfree.facilitator.ExactGasFreeFacilitatorMechanism`.
+ * Uses TRON GasFree (custodial relayer) — user signs TIP-712 permit, the
+ * service provider submits the transaction on-chain.
+ */
+export class ExactGasFreeFacilitatorMechanism implements FacilitatorMechanism {
+  constructor(private readonly fee: ExactGasFreeFee) {}
+
+  scheme(): string {
+    return SCHEME_EXACT_GASFREE;
+  }
+
+  async feeQuote(
+    accept: PaymentRequirements,
+    _context?: Record<string, unknown>,
+  ): Promise<FeeQuoteResponse | null> {
+    const key = `${accept.network}:${accept.asset.toLowerCase()}`;
+    const feeAmount =
+      this.fee.baseFeesByToken?.[key] ?? this.fee.defaultBaseFee ?? '0';
+    return {
+      fee: {
+        feeTo: this.fee.feeTo,
+        feeAmount,
+        ...(this.fee.caller ? { caller: this.fee.caller } : {}),
+      },
+      pricing: 'fixed',
+      scheme: this.scheme(),
+      network: accept.network,
+      asset: accept.asset,
+    };
+  }
+
+  /**
+   * Off-chain verify: structural checks. Real TIP-712 signature + GasFree
+   * API deadline-clamping checks left as TODO.
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    const permit = payload.payload.paymentPermit;
+    if (!permit) {
+      return { isValid: false, invalidReason: 'missing_permit' };
+    }
+    if (permit.payment.payToken !== requirements.asset) {
+      return { isValid: false, invalidReason: 'asset_mismatch' };
+    }
+    if (permit.payment.payTo !== requirements.payTo) {
+      return { isValid: false, invalidReason: 'payTo_mismatch' };
+    }
+    try {
+      if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) {
+        return { isValid: false, invalidReason: 'amount_too_low' };
+      }
+    } catch {
+      return { isValid: false, invalidReason: 'invalid_amount' };
+    }
+    // TODO(v0.6.0b): TIP-712 signature recovery + GasFree balance/deadline check.
+    return { isValid: true };
+  }
+
+  /**
+   * Submit the GasFree permit through the GasFreeController contract.
+   *
+   * TODO(v0.6.0b): call GasFree relayer API or contract directly.
+   */
+  async settle(
+    _payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return {
+      success: false,
+      network: requirements.network,
+      errorReason: 'tron_exact_gasfree_settle_not_implemented',
+    };
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/index.ts
@@ -1,1 +1,4 @@
 export { ExactGasFreeClientMechanism } from './client.js';
+export { ExactGasFreeServerMechanism } from './server.js';
+export { ExactGasFreeFacilitatorMechanism } from './facilitator.js';
+export type { ExactGasFreeFee } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/index.ts
@@ -1,4 +1,4 @@
 export { ExactGasFreeClientMechanism } from './client.js';
 export { ExactGasFreeServerMechanism } from './server.js';
 export { ExactGasFreeFacilitatorMechanism } from './facilitator.js';
-export type { ExactGasFreeFee } from './facilitator.js';
+export type { ExactGasFreeFacilitatorOptions } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/index.ts
@@ -1,0 +1,1 @@
+export { ExactGasFreeClientMechanism } from './client.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/server.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_gasfree/server.ts
@@ -1,0 +1,59 @@
+import { findByAddress, parsePrice } from '../../../tokens.js';
+import type { ServerMechanism } from '../../../server/types.js';
+import type {
+  PaymentPermit,
+  PaymentRequirements,
+} from '../../../types/index.js';
+
+const SCHEME_EXACT_GASFREE = 'exact_gasfree';
+
+/**
+ * TRON server mechanism for the `exact_gasfree` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact_gasfree.server.ExactGasFreeServerMechanism`.
+ * GasFree is TRON-only (no EVM counterpart) so there is no shared
+ * `_exact_gasfree_base/`.
+ */
+export class ExactGasFreeServerMechanism implements ServerMechanism {
+  scheme(): string {
+    return SCHEME_EXACT_GASFREE;
+  }
+
+  async parsePrice(price: string, network: string) {
+    return parsePrice(price, network);
+  }
+
+  async enhancePaymentRequirements(
+    requirements: PaymentRequirements,
+    _deliveryMode: string,
+  ): Promise<PaymentRequirements> {
+    const token = findByAddress(requirements.network, requirements.asset);
+    if (!token) return requirements;
+    return {
+      ...requirements,
+      extra: {
+        ...(requirements.extra ?? {}),
+        name: token.name,
+        ...(token.version ? { version: token.version } : {}),
+      },
+    };
+  }
+
+  validatePaymentRequirements(requirements: PaymentRequirements): boolean {
+    return requirements.network.startsWith('tron:');
+  }
+
+  /**
+   * TIP-712 GasFree permit signature recovery.
+   *
+   * TODO(v0.6.0b): port from Python — TIP-712 hash + signature recovery.
+   * Returns `true` for now; facilitator authoritative.
+   */
+  async verifySignature(
+    _permit: PaymentPermit | null | undefined,
+    _signature: string,
+    _network: string,
+  ): Promise<boolean> {
+    return true;
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/tron/exact_permit/client.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_permit/client.ts
@@ -1,5 +1,7 @@
 /**
- * ExactPermitEvmClientMechanism - EVM client mechanism for "exact_permit" payment scheme
+ * ExactPermitTronClientMechanism - TRON client mechanism for "exact_permit" payment scheme
+ *
+ * Uses TIP-712 (TRON's EIP-712 implementation) for signing PaymentPermit.
  */
 
 import type {
@@ -9,25 +11,25 @@ import type {
   PaymentPayload,
   PaymentPermit,
   PaymentPermitContext,
-} from '../index.js';
+} from '../../../index.js';
 import {
   KIND_MAP,
   PAYMENT_PERMIT_TYPES,
   PAYMENT_PERMIT_PRIMARY_TYPE,
   getChainId,
   getPaymentPermitAddress,
-  EVM_ZERO_ADDRESS,
-  EvmAddressConverter,
-  ZERO_ADDRESS_HEX,
+  TronAddressConverter,
+  TRON_ZERO_ADDRESS,
+  paymentIdToBytes,
   PermitValidationError,
-} from '../index.js';
+} from '../../../index.js';
 
 /**
- * EVM client mechanism for "exact_permit" payment scheme
+ * TRON client mechanism for "exact_permit" payment scheme
  */
-export class ExactPermitEvmClientMechanism implements ClientMechanism {
+export class ExactPermitTronClientMechanism implements ClientMechanism {
   private signer: ClientSigner;
-  private addressConverter = new EvmAddressConverter();
+  private addressConverter = new TronAddressConverter();
 
   constructor(signer: ClientSigner) {
     this.signer = signer;
@@ -52,7 +54,7 @@ export class ExactPermitEvmClientMechanism implements ClientMechanism {
     }
 
     const buyerAddress = this.signer.getAddress();
-    const zeroAddress = EVM_ZERO_ADDRESS;
+    const zeroAddress = TRON_ZERO_ADDRESS; // Use TRON zero address for consistency with Python
 
     const permit: PaymentPermit = {
       meta: {
@@ -83,7 +85,8 @@ export class ExactPermitEvmClientMechanism implements ClientMechanism {
       requirements.network
     );
 
-    // Build EIP-712 domain
+    // Build EIP-712 domain (no version field per contract spec)
+    // Note: domain name is "PaymentPermit", not "PaymentPermitDetails"
     const permitAddress = getPaymentPermitAddress(requirements.network);
     const domain = {
       name: 'PaymentPermit',
@@ -91,11 +94,15 @@ export class ExactPermitEvmClientMechanism implements ClientMechanism {
       verifyingContract: this.addressConverter.toEvmFormat(permitAddress),
     };
 
-    // Convert permit to EIP-712 compatible format
+    // Convert permit to EIP-712 compatible format:
+    // 1. kind: string -> uint8 (number)
+    // 2. paymentId: keep as hex string (TronWeb expects hex for bytes16)
+    // 3. uint256 values: string -> BigInt (for proper EIP-712 encoding)
+    // 4. All addresses: TRON Base58 -> EVM hex
     const permitForSigning = {
       meta: {
         kind: KIND_MAP[permit.meta.kind],
-        paymentId: permit.meta.paymentId,
+        paymentId: permit.meta.paymentId,  // Keep as hex string
         nonce: BigInt(permit.meta.nonce),
         validAfter: permit.meta.validAfter,
         validBefore: permit.meta.validBefore,
@@ -113,12 +120,26 @@ export class ExactPermitEvmClientMechanism implements ClientMechanism {
       },
     };
 
+    // Debug: log exact message being signed
+    console.log('[SIGN] Domain:', JSON.stringify(domain));
+    console.log('[SIGN] Message:', JSON.stringify(permitForSigning, (key, value) => {
+      if (value instanceof Uint8Array) {
+        return '0x' + Array.from(value).map(b => b.toString(16).padStart(2, '0')).join('');
+      }
+      if (typeof value === 'bigint') {
+        return value.toString();
+      }
+      return value;
+    }));
+
     const signature = await this.signer.signTypedData(
       domain,
       PAYMENT_PERMIT_TYPES,
       permitForSigning as unknown as Record<string, unknown>,
       PAYMENT_PERMIT_PRIMARY_TYPE
     );
+
+    console.log('[SIGN] Signature:', signature);
 
     return {
       x402Version: 2,

--- a/typescript/packages/x402/src/mechanisms/tron/exact_permit/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_permit/facilitator.ts
@@ -1,36 +1,124 @@
+/**
+ * TRON facilitator mechanism for the `exact_permit` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact_permit.facilitator.ExactPermitTronFacilitatorMechanism`.
+ *
+ * Settles by calling `PaymentPermit.permitTransferFrom(permit, owner, signature)`
+ * on the configured PaymentPermit contract via the facilitator's TRON signer.
+ */
+
 import {
   BaseExactPermitFacilitatorMechanism,
   type BaseExactPermitFee,
 } from '../../_exact_permit_base/facilitator.js';
 import type {
-  PaymentPayload,
+  PaymentPermit,
   PaymentRequirements,
-  SettleResponse,
 } from '../../../types/index.js';
+import { FacilitatorSigner } from '../../../signers/facilitator/base.js';
+import { TronAddressConverter, type AddressConverter } from '../../../address.js';
+import { getPaymentPermitAddress } from '../../../config.js';
+import { PAYMENT_PERMIT_ABI } from '../../../abi.js';
 
 /**
- * TRON facilitator mechanism for the `exact_permit` scheme.
+ * Function selector with full tuple layout. tronweb's `triggerSmartContract`
+ * needs the exact bracket signature to compute the 4-byte method ID.
  *
- * Mirrors Python `mechanisms.tron.exact_permit.facilitator.ExactPermitTronFacilitatorMechanism`.
+ * Layout mirrors `PAYMENT_PERMIT_ABI.permitTransferFrom`:
+ *   permit: tuple(meta, buyer, caller, payment, fee)
+ *     meta: tuple(uint8 kind, bytes16 paymentId, uint256 nonce, uint256 validAfter, uint256 validBefore)
+ *     payment: tuple(address payToken, uint256 payAmount, address payTo)
+ *     fee: tuple(address feeTo, uint256 feeAmount)
+ *   owner: address
+ *   signature: bytes
  */
+const PERMIT_TRANSFER_FROM_SELECTOR =
+  'permitTransferFrom(' +
+  '(' +
+  '(uint8,bytes16,uint256,uint256,uint256),' +
+  'address,' +
+  'address,' +
+  '(address,uint256,address),' +
+  '(address,uint256)' +
+  '),' +
+  'address,' +
+  'bytes' +
+  ')';
+
+const TUPLE_TYPE =
+  '(' +
+  '(uint8,bytes16,uint256,uint256,uint256),' +
+  'address,' +
+  'address,' +
+  '(address,uint256,address),' +
+  '(address,uint256)' +
+  ')';
+
 export class ExactPermitTronFacilitatorMechanism extends BaseExactPermitFacilitatorMechanism {
-  constructor(fee: BaseExactPermitFee) {
-    super(fee);
+  constructor(signer: FacilitatorSigner, fee: BaseExactPermitFee = {}) {
+    super(signer, fee);
+  }
+
+  protected getAddressConverter(): AddressConverter {
+    return new TronAddressConverter();
   }
 
   /**
-   * Submit `permitTransferFrom` to the TRON PaymentPermit contract.
+   * Call `PaymentPermit.permitTransferFrom` on TRON.
    *
-   * TODO(v0.6.0b): wire tronweb and call `PaymentPermit.permitTransferFrom`.
+   * tronweb's `triggerSmartContract` accepts tuple parameters as an array of
+   * primitive values matching the type layout. Addresses must be 0x EVM hex
+   * (TRON's internal representation for `address` ABI type).
    */
-  async settle(
-    _payload: PaymentPayload,
+  protected async settlePaymentOnly(
+    permit: PaymentPermit,
+    signature: string,
     requirements: PaymentRequirements,
-  ): Promise<SettleResponse> {
-    return {
-      success: false,
-      network: requirements.network,
-      errorReason: 'tron_exact_permit_settle_not_implemented',
-    };
+  ): Promise<string | null> {
+    const contractAddress = getPaymentPermitAddress(requirements.network);
+    const converter = this.addressConverter;
+    const hex = (s: string) => converter.toEvmFormat(s);
+
+    // Build the tuple as an array of primitive values (NOT objects).
+    // tronweb's tuple encoder expects the array order to match the type signature.
+    const permitTupleValue = [
+      // meta: (uint8, bytes16, uint256, uint256, uint256)
+      [
+        // kind (PAYMENT_ONLY → 0)
+        permit.meta.kind === 'PAYMENT_ONLY' ? 0 : 0,
+        // paymentId — bytes16, accepted as hex string by tronweb
+        permit.meta.paymentId,
+        // nonce — uint256, accepted as string
+        permit.meta.nonce,
+        permit.meta.validAfter,
+        permit.meta.validBefore,
+      ],
+      hex(permit.buyer),
+      hex(permit.caller),
+      // payment: (address, uint256, address)
+      [
+        hex(permit.payment.payToken),
+        permit.payment.payAmount,
+        hex(permit.payment.payTo),
+      ],
+      // fee: (address, uint256)
+      [hex(permit.fee.feeTo), permit.fee.feeAmount],
+    ];
+
+    const sigBytes = signature.startsWith('0x') ? signature : `0x${signature}`;
+
+    const args = [
+      { type: TUPLE_TYPE, value: permitTupleValue },
+      { type: 'address', value: hex(permit.buyer) },
+      { type: 'bytes', value: sigBytes },
+    ];
+
+    return this.signer.writeContract(
+      contractAddress,
+      PAYMENT_PERMIT_ABI as unknown as unknown[],
+      PERMIT_TRANSFER_FROM_SELECTOR,
+      args,
+      requirements.network,
+    );
   }
 }

--- a/typescript/packages/x402/src/mechanisms/tron/exact_permit/facilitator.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_permit/facilitator.ts
@@ -1,0 +1,36 @@
+import {
+  BaseExactPermitFacilitatorMechanism,
+  type BaseExactPermitFee,
+} from '../../_exact_permit_base/facilitator.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+} from '../../../types/index.js';
+
+/**
+ * TRON facilitator mechanism for the `exact_permit` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact_permit.facilitator.ExactPermitTronFacilitatorMechanism`.
+ */
+export class ExactPermitTronFacilitatorMechanism extends BaseExactPermitFacilitatorMechanism {
+  constructor(fee: BaseExactPermitFee) {
+    super(fee);
+  }
+
+  /**
+   * Submit `permitTransferFrom` to the TRON PaymentPermit contract.
+   *
+   * TODO(v0.6.0b): wire tronweb and call `PaymentPermit.permitTransferFrom`.
+   */
+  async settle(
+    _payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    return {
+      success: false,
+      network: requirements.network,
+      errorReason: 'tron_exact_permit_settle_not_implemented',
+    };
+  }
+}

--- a/typescript/packages/x402/src/mechanisms/tron/exact_permit/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_permit/index.ts
@@ -1,1 +1,3 @@
 export { ExactPermitTronClientMechanism } from './client.js';
+export { ExactPermitTronServerMechanism } from './server.js';
+export { ExactPermitTronFacilitatorMechanism } from './facilitator.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact_permit/index.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_permit/index.ts
@@ -1,0 +1,1 @@
+export { ExactPermitTronClientMechanism } from './client.js';

--- a/typescript/packages/x402/src/mechanisms/tron/exact_permit/server.ts
+++ b/typescript/packages/x402/src/mechanisms/tron/exact_permit/server.ts
@@ -1,0 +1,20 @@
+import { BaseExactPermitServerMechanism } from '../../_exact_permit_base/server.js';
+
+/**
+ * TRON server mechanism for the `exact_permit` scheme.
+ *
+ * Mirrors Python `mechanisms.tron.exact_permit.server.ExactPermitTronServerMechanism`.
+ */
+export class ExactPermitTronServerMechanism extends BaseExactPermitServerMechanism {
+  protected getNetworkPrefix(): string {
+    return 'tron:';
+  }
+
+  protected validateAddressFormat(address: string): boolean {
+    if (typeof address !== 'string') return false;
+    // Accept both Base58 (T...) and 0x-prefixed hex forms
+    if (address.startsWith('T') && address.length === 34) return true;
+    if (address.startsWith('0x') && address.length === 42) return true;
+    return false;
+  }
+}

--- a/typescript/packages/x402/src/middleware/core.test.ts
+++ b/typescript/packages/x402/src/middleware/core.test.ts
@@ -81,12 +81,35 @@ describe('processX402Request', () => {
       accepts: [TRON_REQ],
       resource: { url: 'http://example.com/api', description: 'demo' },
       extensions: { 'payment-identifier': { info: { required: false } } },
+      enrich: false, // legacy passthrough; don't generate paymentPermitContext
     };
 
     const decision = await processX402Request(null, config);
     if (decision.kind !== 'paymentRequired') throw new Error('expected paymentRequired');
     expect(decision.paymentRequired.resource).toEqual(config.resource);
     expect(decision.paymentRequired.extensions).toEqual(config.extensions);
+  });
+
+  it('enriches with fresh paymentPermitContext per challenge by default', async () => {
+    const config: X402MiddlewareConfig = {
+      facilitator: makeFacilitator({}),
+      accepts: [TRON_REQ],
+    };
+    const a = await processX402Request(null, config);
+    const b = await processX402Request(null, config);
+    if (a.kind !== 'paymentRequired' || b.kind !== 'paymentRequired') {
+      throw new Error('expected paymentRequired');
+    }
+    const ctxA = a.paymentRequired.extensions?.paymentPermitContext as
+      | { meta: { paymentId: string; nonce: string } }
+      | undefined;
+    const ctxB = b.paymentRequired.extensions?.paymentPermitContext as
+      | { meta: { paymentId: string; nonce: string } }
+      | undefined;
+    expect(ctxA?.meta.paymentId).toMatch(/^0x[0-9a-f]{32}$/);
+    expect(ctxB?.meta.paymentId).toMatch(/^0x[0-9a-f]{32}$/);
+    expect(ctxA?.meta.paymentId).not.toBe(ctxB?.meta.paymentId);
+    expect(ctxA?.meta.nonce).not.toBe(ctxB?.meta.nonce);
   });
 
   it('returns 400 invalid when signature header is unparseable', async () => {

--- a/typescript/packages/x402/src/middleware/core.test.ts
+++ b/typescript/packages/x402/src/middleware/core.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the framework-agnostic middleware core.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FacilitatorClient } from '../facilitator/client.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import { decodePaymentPayload, encodePaymentPayload } from '../utils/encoding.js';
+import {
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  processX402Request,
+  X402_VERSION,
+  type X402MiddlewareConfig,
+} from './core.js';
+
+const TRON_REQ: PaymentRequirements = {
+  scheme: 'exact_permit',
+  network: 'tron:nile',
+  amount: '1000000',
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+};
+
+function makeFacilitator(opts: {
+  verify?: VerifyResponse | (() => Promise<VerifyResponse>);
+  settle?: SettleResponse | (() => Promise<SettleResponse>);
+}): FacilitatorClient {
+  return {
+    verify: vi.fn(async () =>
+      typeof opts.verify === 'function'
+        ? await opts.verify()
+        : (opts.verify ?? { isValid: true }),
+    ),
+    settle: vi.fn(async () =>
+      typeof opts.settle === 'function'
+        ? await opts.settle()
+        : (opts.settle ?? { success: true, transaction: '0xtx', network: 'tron:nile' }),
+    ),
+  } as unknown as FacilitatorClient;
+}
+
+function makePayload(req: PaymentRequirements): PaymentPayload {
+  return {
+    x402Version: X402_VERSION,
+    accepted: req,
+    payload: { signature: '0x' + 'aa'.repeat(65) },
+  };
+}
+
+describe('processX402Request', () => {
+  it('returns 402 + PAYMENT-REQUIRED when no signature header', async () => {
+    const config: X402MiddlewareConfig = {
+      facilitator: makeFacilitator({}),
+      accepts: [TRON_REQ],
+    };
+
+    const decision = await processX402Request(null, config);
+
+    expect(decision.kind).toBe('paymentRequired');
+    if (decision.kind !== 'paymentRequired') return;
+    expect(decision.status).toBe(402);
+    expect(decision.headers[PAYMENT_REQUIRED_HEADER]).toBeTypeOf('string');
+    expect(decision.paymentRequired.x402Version).toBe(X402_VERSION);
+    expect(decision.paymentRequired.accepts).toEqual([TRON_REQ]);
+
+    // Header round-trips back to the same body.
+    const decoded = decodePaymentPayload(decision.headers[PAYMENT_REQUIRED_HEADER]!);
+    expect(decoded).toEqual(decision.paymentRequired);
+  });
+
+  it('echoes resource + extensions when configured', async () => {
+    const config: X402MiddlewareConfig = {
+      facilitator: makeFacilitator({}),
+      accepts: [TRON_REQ],
+      resource: { url: 'http://example.com/api', description: 'demo' },
+      extensions: { 'payment-identifier': { info: { required: false } } },
+    };
+
+    const decision = await processX402Request(null, config);
+    if (decision.kind !== 'paymentRequired') throw new Error('expected paymentRequired');
+    expect(decision.paymentRequired.resource).toEqual(config.resource);
+    expect(decision.paymentRequired.extensions).toEqual(config.extensions);
+  });
+
+  it('returns 400 invalid when signature header is unparseable', async () => {
+    const config: X402MiddlewareConfig = {
+      facilitator: makeFacilitator({}),
+      accepts: [TRON_REQ],
+    };
+
+    const decision = await processX402Request('not-base64-json', config);
+
+    expect(decision.kind).toBe('invalid');
+    if (decision.kind !== 'invalid') return;
+    expect(decision.status).toBe(400);
+    expect(decision.reason).toMatch(/Invalid payment payload/);
+  });
+
+  it("returns 400 invalid when client's accepted entry doesn't match offer", async () => {
+    const config: X402MiddlewareConfig = {
+      facilitator: makeFacilitator({}),
+      accepts: [TRON_REQ],
+    };
+    const wrongPayload = makePayload({ ...TRON_REQ, network: 'tron:mainnet' });
+    const header = encodePaymentPayload(wrongPayload);
+
+    const decision = await processX402Request(header, config);
+
+    expect(decision.kind).toBe('invalid');
+    if (decision.kind !== 'invalid') return;
+    expect(decision.reason).toMatch(/Unsupported payment/);
+  });
+
+  it('returns 500 failed when facilitator.verify rejects', async () => {
+    const facilitator = makeFacilitator({
+      verify: { isValid: false, invalidReason: 'bad signature' },
+    });
+    const config: X402MiddlewareConfig = { facilitator, accepts: [TRON_REQ] };
+    const header = encodePaymentPayload(makePayload(TRON_REQ));
+
+    const decision = await processX402Request(header, config);
+
+    expect(decision.kind).toBe('failed');
+    if (decision.kind !== 'failed') return;
+    expect(decision.reason).toBe('bad signature');
+  });
+
+  it('returns 500 failed when verify throws', async () => {
+    const facilitator = makeFacilitator({
+      verify: async () => {
+        throw new Error('connection reset');
+      },
+    });
+    const config: X402MiddlewareConfig = { facilitator, accepts: [TRON_REQ] };
+    const header = encodePaymentPayload(makePayload(TRON_REQ));
+
+    const decision = await processX402Request(header, config);
+
+    expect(decision.kind).toBe('failed');
+    if (decision.kind !== 'failed') return;
+    expect(decision.reason).toMatch(/Verify request failed: connection reset/);
+  });
+
+  it('returns 500 failed when settle returns success:false', async () => {
+    const facilitator = makeFacilitator({
+      settle: {
+        success: false,
+        errorReason: 'insufficient balance',
+        transaction: '0xabc',
+        network: 'tron:nile',
+      },
+    });
+    const config: X402MiddlewareConfig = { facilitator, accepts: [TRON_REQ] };
+    const header = encodePaymentPayload(makePayload(TRON_REQ));
+
+    const decision = await processX402Request(header, config);
+
+    expect(decision.kind).toBe('failed');
+    if (decision.kind !== 'failed') return;
+    expect(decision.reason).toBe('insufficient balance');
+    expect(decision.transaction).toBe('0xabc');
+    expect(decision.network).toBe('tron:nile');
+  });
+
+  it('returns allow + PAYMENT-RESPONSE on success', async () => {
+    const settled: SettleResponse = {
+      success: true,
+      transaction: '0xdeadbeef',
+      network: 'tron:nile',
+    };
+    const facilitator = makeFacilitator({ settle: settled });
+    const config: X402MiddlewareConfig = { facilitator, accepts: [TRON_REQ] };
+    const header = encodePaymentPayload(makePayload(TRON_REQ));
+
+    const decision = await processX402Request(header, config);
+
+    expect(decision.kind).toBe('allow');
+    if (decision.kind !== 'allow') return;
+    expect(decision.settleResult).toEqual(settled);
+    const decoded = decodePaymentPayload(decision.headers[PAYMENT_RESPONSE_HEADER]!);
+    expect(decoded).toEqual(settled);
+  });
+
+  it('matches accepts with case-insensitive asset / payTo comparison', async () => {
+    const facilitator = makeFacilitator({});
+    const config: X402MiddlewareConfig = {
+      facilitator,
+      accepts: [TRON_REQ],
+    };
+    const payload = makePayload({
+      ...TRON_REQ,
+      asset: TRON_REQ.asset.toUpperCase(),
+      payTo: TRON_REQ.payTo.toUpperCase(),
+    });
+
+    const decision = await processX402Request(encodePaymentPayload(payload), config);
+
+    expect(decision.kind).toBe('allow');
+  });
+});

--- a/typescript/packages/x402/src/middleware/core.ts
+++ b/typescript/packages/x402/src/middleware/core.ts
@@ -12,6 +12,11 @@
  */
 
 import type { FacilitatorClient } from '../facilitator/client.js';
+import {
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  PAYMENT_SIGNATURE_HEADER,
+} from '../http/client.js';
 import type {
   PaymentPayload,
   PaymentRequired,
@@ -23,10 +28,12 @@ import {
   encodePaymentPayload,
 } from '../utils/encoding.js';
 
-/** Header names — match the x402 spec exactly (case-insensitive on the wire). */
-export const PAYMENT_SIGNATURE_HEADER = 'PAYMENT-SIGNATURE';
-export const PAYMENT_REQUIRED_HEADER = 'PAYMENT-REQUIRED';
-export const PAYMENT_RESPONSE_HEADER = 'PAYMENT-RESPONSE';
+// Re-export header constants from http/client (single source of truth).
+export {
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  PAYMENT_SIGNATURE_HEADER,
+};
 
 export const X402_VERSION = 2;
 

--- a/typescript/packages/x402/src/middleware/core.ts
+++ b/typescript/packages/x402/src/middleware/core.ts
@@ -26,6 +26,7 @@ import type {
 import {
   decodePaymentPayload,
   encodePaymentPayload,
+  generatePaymentId,
 } from '../utils/encoding.js';
 
 // Re-export header constants from http/client (single source of truth).
@@ -50,9 +51,21 @@ export interface X402MiddlewareConfig {
   resource?: PaymentRequired['resource'];
   /**
    * Optional extensions advertised on the 402 (e.g. `payment-identifier`).
-   * Forwarded as-is into the `PaymentRequired.extensions` field.
+   * Forwarded as-is into the `PaymentRequired.extensions` field. When
+   * `enrich` is true (default), `paymentPermitContext` is generated per
+   * request and merged into this object.
    */
   extensions?: PaymentRequired['extensions'];
+  /**
+   * When true (default), the middleware enriches the 402 challenge per-request:
+   * - calls `facilitator.feeQuote()` for permit-style accepts and attaches
+   *   the result to `accept.extra.fee`
+   * - generates fresh `paymentPermitContext` (paymentId/nonce/validAfter/validBefore)
+   *
+   * Set `false` to keep the legacy passthrough behavior — useful when the
+   * caller has already enriched the requirements via {@link X402Server}.
+   */
+  enrich?: boolean;
 }
 
 /** Outcome of {@link processX402Request}. The adapter renders this. */
@@ -100,7 +113,7 @@ export async function processX402Request(
   config: X402MiddlewareConfig,
 ): Promise<X402Decision> {
   if (!signatureHeader) {
-    const paymentRequired = buildPaymentRequired(config);
+    const paymentRequired = await buildPaymentRequired(config);
     return {
       kind: 'paymentRequired',
       status: 402,
@@ -178,14 +191,87 @@ export async function processX402Request(
   };
 }
 
-/** Build the 402 challenge body from the middleware config. */
-function buildPaymentRequired(config: X402MiddlewareConfig): PaymentRequired {
+/**
+ * Build the 402 challenge body. When `enrich: true`, fetches `feeQuote` from
+ * the facilitator for permit-style accepts and generates a fresh
+ * `paymentPermitContext` (paymentId/nonce/validAfter/validBefore) per request.
+ *
+ * Mirrors Python `X402Server.create_payment_required_response`.
+ */
+async function buildPaymentRequired(
+  config: X402MiddlewareConfig,
+): Promise<PaymentRequired> {
+  let accepts = config.accepts;
+  let extensions = config.extensions;
+
+  if (config.enrich !== false) {
+    // Enrich accepts with extra.fee for permit-style schemes
+    const permitReqs = config.accepts.filter((a) => a.scheme !== 'exact');
+    if (permitReqs.length > 0) {
+      try {
+        const quotes = await config.facilitator.feeQuote(permitReqs);
+        const quoteMap = new Map<string, (typeof quotes)[number]>();
+        for (const q of quotes) {
+          quoteMap.set(`${q.scheme}|${q.network}|${q.asset}`, q);
+        }
+        accepts = config.accepts
+          .map((a) => {
+            if (a.scheme === 'exact') return a;
+            const quote = quoteMap.get(`${a.scheme}|${a.network}|${a.asset}`);
+            if (!quote) return null;
+            return {
+              ...a,
+              extra: {
+                ...(a.extra ?? {}),
+                fee: {
+                  ...quote.fee,
+                  facilitatorId: config.facilitator.facilitatorId,
+                },
+              },
+            };
+          })
+          .filter((a): a is PaymentRequirements => a !== null);
+      } catch {
+        // If feeQuote fails, fall through with un-enriched accepts. Facilitator
+        // may still accept the request, or signal at verify time.
+      }
+    }
+
+    // Generate fresh paymentPermitContext per challenge
+    const now = Math.floor(Date.now() / 1000);
+    const validAfter = now;
+    const validBefore = now + 3600;
+    extensions = {
+      ...(extensions ?? {}),
+      paymentPermitContext: {
+        meta: {
+          kind: 'PAYMENT_ONLY',
+          paymentId: generatePaymentId(),
+          nonce: generateNonce(),
+          validAfter,
+          validBefore,
+        },
+      },
+    } as PaymentRequired['extensions'];
+  }
+
   return {
     x402Version: X402_VERSION,
-    accepts: config.accepts,
+    accepts,
     ...(config.resource ? { resource: config.resource } : {}),
-    ...(config.extensions ? { extensions: config.extensions } : {}),
+    ...(extensions ? { extensions } : {}),
   };
+}
+
+function generateNonce(): string {
+  // 16 random bytes, decimal-encoded — matches Python's `str(uuid.uuid4().int)`.
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let nonce = 0n;
+  for (const byte of bytes) {
+    nonce = (nonce << 8n) | BigInt(byte);
+  }
+  return nonce.toString();
 }
 
 /**

--- a/typescript/packages/x402/src/middleware/core.ts
+++ b/typescript/packages/x402/src/middleware/core.ts
@@ -1,0 +1,203 @@
+/**
+ * Framework-agnostic core for x402 server middleware.
+ *
+ * Implements the verify → settle → header-attach pipeline used by all
+ * server adapters (Hono, Express, Fastify, ...). Adapters read the request
+ * headers, hand them to {@link processX402Request}, then translate the
+ * resulting {@link X402Decision} back into their framework's response shape.
+ *
+ * This mirrors `bankofai.x402.fastapi.X402Middleware` on the Python side but
+ * splits the framework binding from the protocol logic so we can target any
+ * Node.js HTTP framework with a thin adapter.
+ */
+
+import type { FacilitatorClient } from '../facilitator/client.js';
+import type {
+  PaymentPayload,
+  PaymentRequired,
+  PaymentRequirements,
+  SettleResponse,
+} from '../types/index.js';
+import {
+  decodePaymentPayload,
+  encodePaymentPayload,
+} from '../utils/encoding.js';
+
+/** Header names — match the x402 spec exactly (case-insensitive on the wire). */
+export const PAYMENT_SIGNATURE_HEADER = 'PAYMENT-SIGNATURE';
+export const PAYMENT_REQUIRED_HEADER = 'PAYMENT-REQUIRED';
+export const PAYMENT_RESPONSE_HEADER = 'PAYMENT-RESPONSE';
+
+export const X402_VERSION = 2;
+
+/** Minimum config needed to protect an endpoint. */
+export interface X402MiddlewareConfig {
+  /** Facilitator client used for `/verify` and `/settle`. */
+  facilitator: FacilitatorClient;
+  /**
+   * `accepts` array advertised in the 402 challenge. Multiple entries express
+   * multi-token / multi-scheme acceptance — clients pick one and pay it.
+   */
+  accepts: PaymentRequirements[];
+  /** Optional resource info echoed back in the 402 body. */
+  resource?: PaymentRequired['resource'];
+  /**
+   * Optional extensions advertised on the 402 (e.g. `payment-identifier`).
+   * Forwarded as-is into the `PaymentRequired.extensions` field.
+   */
+  extensions?: PaymentRequired['extensions'];
+}
+
+/** Outcome of {@link processX402Request}. The adapter renders this. */
+export type X402Decision =
+  /** No payment header → return a 402 with PAYMENT-REQUIRED set. */
+  | {
+      kind: 'paymentRequired';
+      status: 402;
+      paymentRequired: PaymentRequired;
+      headers: Record<string, string>;
+    }
+  /** Payload was malformed or doesn't match any acceptable requirement. */
+  | {
+      kind: 'invalid';
+      status: 400;
+      reason: string;
+    }
+  /** Verify or settle failed → tell the client. */
+  | {
+      kind: 'failed';
+      status: 500;
+      reason: string;
+      transaction?: string;
+      network?: string;
+    }
+  /**
+   * Payment succeeded. Adapter should run the protected handler and attach
+   * `headers` (which contains `PAYMENT-RESPONSE`) onto the response.
+   */
+  | {
+      kind: 'allow';
+      settleResult: SettleResponse;
+      headers: Record<string, string>;
+    };
+
+/**
+ * Run one x402 protocol iteration against the given config.
+ *
+ * @param signatureHeader - Value of the `PAYMENT-SIGNATURE` request header (or
+ *   null/undefined if absent).
+ * @param config - Server-side payment configuration.
+ */
+export async function processX402Request(
+  signatureHeader: string | null | undefined,
+  config: X402MiddlewareConfig,
+): Promise<X402Decision> {
+  if (!signatureHeader) {
+    const paymentRequired = buildPaymentRequired(config);
+    return {
+      kind: 'paymentRequired',
+      status: 402,
+      paymentRequired,
+      headers: {
+        [PAYMENT_REQUIRED_HEADER]: encodePaymentPayload(paymentRequired),
+      },
+    };
+  }
+
+  let payload: PaymentPayload;
+  try {
+    payload = decodePaymentPayload<PaymentPayload>(signatureHeader);
+  } catch (err) {
+    return {
+      kind: 'invalid',
+      status: 400,
+      reason: `Invalid payment payload: ${(err as Error).message}`,
+    };
+  }
+
+  const matched = matchAccepts(config.accepts, payload);
+  if (!matched) {
+    return {
+      kind: 'invalid',
+      status: 400,
+      reason: 'Unsupported payment token / network / scheme',
+    };
+  }
+
+  let verifyResult;
+  try {
+    verifyResult = await config.facilitator.verify(payload, matched);
+  } catch (err) {
+    return {
+      kind: 'failed',
+      status: 500,
+      reason: `Verify request failed: ${(err as Error).message}`,
+    };
+  }
+  if (!verifyResult.isValid) {
+    return {
+      kind: 'failed',
+      status: 500,
+      reason: verifyResult.invalidReason ?? 'verify rejected payment',
+    };
+  }
+
+  let settleResult: SettleResponse;
+  try {
+    settleResult = await config.facilitator.settle(payload, matched);
+  } catch (err) {
+    return {
+      kind: 'failed',
+      status: 500,
+      reason: `Settle request failed: ${(err as Error).message}`,
+    };
+  }
+  if (!settleResult.success) {
+    return {
+      kind: 'failed',
+      status: 500,
+      reason: settleResult.errorReason ?? 'settle failed',
+      transaction: settleResult.transaction,
+      network: settleResult.network,
+    };
+  }
+
+  return {
+    kind: 'allow',
+    settleResult,
+    headers: {
+      [PAYMENT_RESPONSE_HEADER]: encodePaymentPayload(settleResult),
+    },
+  };
+}
+
+/** Build the 402 challenge body from the middleware config. */
+function buildPaymentRequired(config: X402MiddlewareConfig): PaymentRequired {
+  return {
+    x402Version: X402_VERSION,
+    accepts: config.accepts,
+    ...(config.resource ? { resource: config.resource } : {}),
+    ...(config.extensions ? { extensions: config.extensions } : {}),
+  };
+}
+
+/**
+ * Pick the `accepts[]` entry that matches the client's chosen payment.
+ *
+ * The wire format requires the client to echo `payload.accepted` — we trust
+ * that as the discriminator and verify it lines up with our offer.
+ */
+function matchAccepts(
+  accepts: PaymentRequirements[],
+  payload: PaymentPayload,
+): PaymentRequirements | null {
+  const want = payload.accepted;
+  for (const offer of accepts) {
+    if (offer.network !== want.network) continue;
+    if (offer.scheme !== want.scheme) continue;
+    if (offer.asset.toLowerCase() !== want.asset.toLowerCase()) continue;
+    if (offer.payTo.toLowerCase() !== want.payTo.toLowerCase()) continue;
+    return offer;
+  }
+  return null;
+}

--- a/typescript/packages/x402/src/middleware/express.test.ts
+++ b/typescript/packages/x402/src/middleware/express.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Integration tests for the Express adapter.
+ *
+ * Drives the middleware via a fake (Request, Response, next) pair so we don't
+ * need a real listening server.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FacilitatorClient } from '../facilitator/client.js';
+import {
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  PAYMENT_SIGNATURE_HEADER,
+} from '../http/client.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import { decodePaymentPayload, encodePaymentPayload } from '../utils/encoding.js';
+import { x402Express } from './express.js';
+
+const REQ: PaymentRequirements = {
+  scheme: 'exact_permit',
+  network: 'tron:nile',
+  amount: '1000000',
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+};
+
+function fakeFacilitator(
+  verify: VerifyResponse,
+  settle: SettleResponse,
+): FacilitatorClient {
+  const fetchImpl: typeof fetch = vi.fn(async (input) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url.endsWith('/verify')) return new Response(JSON.stringify(verify), { status: 200 });
+    if (url.endsWith('/settle')) return new Response(JSON.stringify(settle), { status: 200 });
+    return new Response('nf', { status: 404 });
+  }) as unknown as typeof fetch;
+  return new FacilitatorClient({ baseUrl: 'https://fac.test', fetchImpl });
+}
+
+interface FakeResult {
+  status: number;
+  body: unknown;
+  headers: Record<string, string>;
+  nextCalled: boolean;
+}
+
+/** Pure-JS stub that records what the middleware did. */
+function makeReqRes(headers: Record<string, string> = {}): {
+  req: Request;
+  res: Response;
+  next: NextFunction;
+  result: FakeResult;
+} {
+  const result: FakeResult = { status: 0, body: undefined, headers: {}, nextCalled: false };
+  const req = {
+    headers: Object.fromEntries(
+      Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+    ),
+  } as unknown as Request;
+  const res = {
+    setHeader: vi.fn((k: string, v: string) => {
+      result.headers[k] = v;
+    }),
+    status: vi.fn((code: number) => {
+      result.status = code;
+      return res;
+    }),
+    json: vi.fn((b: unknown) => {
+      result.body = b;
+      if (result.status === 0) result.status = 200;
+      return res;
+    }),
+  } as unknown as Response;
+  const next: NextFunction = vi.fn(() => {
+    result.nextCalled = true;
+  });
+  return { req, res, next, result };
+}
+
+describe('x402Express integration', () => {
+  it('returns 402 + PAYMENT-REQUIRED when no signature', async () => {
+    const handler = x402Express({
+      facilitator: fakeFacilitator({ isValid: true }, { success: true }),
+      accepts: [REQ],
+    });
+    const { req, res, next, result } = makeReqRes();
+
+    await handler(req, res, next);
+
+    expect(result.status).toBe(402);
+    expect(result.nextCalled).toBe(false);
+    expect(result.headers[PAYMENT_REQUIRED_HEADER]).toBeTruthy();
+    expect((result.body as { accepts: unknown }).accepts).toEqual([REQ]);
+  });
+
+  it('calls next() + attaches PAYMENT-RESPONSE on valid payment', async () => {
+    const settled: SettleResponse = {
+      success: true,
+      transaction: '0xabc',
+      network: 'tron:nile',
+    };
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      accepted: REQ,
+      payload: { signature: '0x' + 'aa'.repeat(65) },
+    };
+    const handler = x402Express({
+      facilitator: fakeFacilitator({ isValid: true }, settled),
+      accepts: [REQ],
+    });
+    const { req, res, next, result } = makeReqRes({
+      [PAYMENT_SIGNATURE_HEADER]: encodePaymentPayload(payload),
+    });
+
+    await handler(req, res, next);
+
+    expect(result.nextCalled).toBe(true);
+    expect(result.headers[PAYMENT_RESPONSE_HEADER]).toBeTruthy();
+    expect(
+      decodePaymentPayload<SettleResponse>(result.headers[PAYMENT_RESPONSE_HEADER]!),
+    ).toEqual(settled);
+    expect(result.status).toBe(0); // handler not invoked, status not set
+  });
+
+  it('returns 400 on malformed signature', async () => {
+    const handler = x402Express({
+      facilitator: fakeFacilitator({ isValid: true }, { success: true }),
+      accepts: [REQ],
+    });
+    const { req, res, next, result } = makeReqRes({
+      [PAYMENT_SIGNATURE_HEADER]: 'not-base64-json',
+    });
+
+    await handler(req, res, next);
+
+    expect(result.status).toBe(400);
+    expect(result.nextCalled).toBe(false);
+    expect((result.body as { error: string }).error).toMatch(/Invalid payment payload/);
+  });
+
+  it('returns 500 with txHash + network on settle failure', async () => {
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      accepted: REQ,
+      payload: { signature: '0x' + 'aa'.repeat(65) },
+    };
+    const handler = x402Express({
+      facilitator: fakeFacilitator(
+        { isValid: true },
+        {
+          success: false,
+          errorReason: 'insufficient',
+          transaction: '0xabc',
+          network: 'tron:nile',
+        },
+      ),
+      accepts: [REQ],
+    });
+    const { req, res, next, result } = makeReqRes({
+      [PAYMENT_SIGNATURE_HEADER]: encodePaymentPayload(payload),
+    });
+
+    await handler(req, res, next);
+
+    expect(result.status).toBe(500);
+    expect(result.nextCalled).toBe(false);
+    const body = result.body as Record<string, unknown>;
+    expect(body.error).toBe('insufficient');
+    expect(body.txHash).toBe('0xabc');
+    expect(body.network).toBe('tron:nile');
+  });
+});

--- a/typescript/packages/x402/src/middleware/express.ts
+++ b/typescript/packages/x402/src/middleware/express.ts
@@ -1,0 +1,88 @@
+/**
+ * Express adapter for the x402 server middleware.
+ *
+ * Usage:
+ * ```ts
+ * import express from 'express';
+ * import { FacilitatorClient, x402Express } from '@bankofai/x402';
+ *
+ * const facilitator = new FacilitatorClient({ baseUrl: 'https://facilitator.example' });
+ * const app = express();
+ *
+ * app.use(
+ *   '/api/llm-summary',
+ *   x402Express({
+ *     facilitator,
+ *     accepts: [{
+ *       scheme: 'exact_permit',
+ *       network: 'eip155:97',
+ *       amount: '1000000',
+ *       asset: '0x...',
+ *       payTo: '0x...',
+ *     }],
+ *   }),
+ * );
+ *
+ * app.get('/api/llm-summary', (req, res) => res.json({ summary: '...' }));
+ * ```
+ *
+ * Express is imported via `peerDependencies`; consumers add it to their app.
+ */
+
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import {
+  PAYMENT_SIGNATURE_HEADER,
+  processX402Request,
+  type X402MiddlewareConfig,
+} from './core.js';
+
+/**
+ * Build an Express request handler that gates the route on x402 payment.
+ *
+ * Behavior matches the Hono adapter — see {@link X402MiddlewareConfig} and
+ * {@link processX402Request} for the underlying decision logic.
+ */
+export function x402Express(config: X402MiddlewareConfig): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const signature = readHeader(req, PAYMENT_SIGNATURE_HEADER);
+    let decision;
+    try {
+      decision = await processX402Request(signature, config);
+    } catch (err) {
+      next(err);
+      return;
+    }
+
+    switch (decision.kind) {
+      case 'paymentRequired':
+        for (const [k, v] of Object.entries(decision.headers)) {
+          res.setHeader(k, v);
+        }
+        res.status(402).json(decision.paymentRequired);
+        return;
+      case 'invalid':
+        res.status(400).json({ error: decision.reason });
+        return;
+      case 'failed': {
+        const body: Record<string, unknown> = { error: decision.reason };
+        if (decision.transaction) body.txHash = decision.transaction;
+        if (decision.network) body.network = decision.network;
+        res.status(500).json(body);
+        return;
+      }
+      case 'allow':
+        for (const [k, v] of Object.entries(decision.headers)) {
+          res.setHeader(k, v);
+        }
+        next();
+        return;
+    }
+  };
+}
+
+function readHeader(req: Request, name: string): string | null {
+  const raw = req.headers[name.toLowerCase()];
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  return raw ?? null;
+}

--- a/typescript/packages/x402/src/middleware/hono.test.ts
+++ b/typescript/packages/x402/src/middleware/hono.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for the Hono adapter — proves FacilitatorClient + middleware
+ * core + Hono adapter compose correctly through the wire.
+ */
+
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FacilitatorClient } from '../facilitator/client.js';
+import { PAYMENT_REQUIRED_HEADER, PAYMENT_RESPONSE_HEADER, PAYMENT_SIGNATURE_HEADER } from '../http/client.js';
+import type {
+  PaymentPayload,
+  PaymentRequired,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import { decodePaymentPayload, encodePaymentPayload } from '../utils/encoding.js';
+import { x402Hono } from './hono.js';
+
+const REQ: PaymentRequirements = {
+  scheme: 'exact_permit',
+  network: 'tron:nile',
+  amount: '1000000',
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+};
+
+/** Build a FacilitatorClient whose fetch returns canned verify/settle bodies. */
+function fakeFacilitator(verify: VerifyResponse, settle: SettleResponse): FacilitatorClient {
+  const fetchImpl: typeof fetch = vi.fn(async (input) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url.endsWith('/verify')) {
+      return new Response(JSON.stringify(verify), { status: 200 });
+    }
+    if (url.endsWith('/settle')) {
+      return new Response(JSON.stringify(settle), { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+  return new FacilitatorClient({ baseUrl: 'https://fac.test', fetchImpl });
+}
+
+function buildPayload(req: PaymentRequirements = REQ): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: req,
+    payload: { signature: '0x' + 'aa'.repeat(65) },
+  };
+}
+
+describe('x402Hono integration', () => {
+  it('returns 402 with PAYMENT-REQUIRED on bare request', async () => {
+    const app = new Hono();
+    app.use(
+      '/api/data',
+      x402Hono({
+        facilitator: fakeFacilitator({ isValid: true }, { success: true }),
+        accepts: [REQ],
+      }),
+    );
+    app.get('/api/data', (c) => c.json({ data: 'secret' }));
+
+    const res = await app.request('/api/data');
+
+    expect(res.status).toBe(402);
+    const headerValue = res.headers.get(PAYMENT_REQUIRED_HEADER);
+    expect(headerValue).toBeTruthy();
+    const decoded = decodePaymentPayload<PaymentRequired>(headerValue!);
+    expect(decoded.accepts).toEqual([REQ]);
+  });
+
+  it('serves the protected route on valid PAYMENT-SIGNATURE + attaches PAYMENT-RESPONSE', async () => {
+    const settled: SettleResponse = {
+      success: true,
+      transaction: '0xabc',
+      network: 'tron:nile',
+    };
+    const app = new Hono();
+    app.use(
+      '/api/data',
+      x402Hono({
+        facilitator: fakeFacilitator({ isValid: true }, settled),
+        accepts: [REQ],
+      }),
+    );
+    app.get('/api/data', (c) => c.json({ data: 'secret' }));
+
+    const res = await app.request('/api/data', {
+      headers: { [PAYMENT_SIGNATURE_HEADER]: encodePaymentPayload(buildPayload()) },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: string };
+    expect(body.data).toBe('secret');
+    const settleHeader = res.headers.get(PAYMENT_RESPONSE_HEADER);
+    expect(settleHeader).toBeTruthy();
+    expect(decodePaymentPayload<SettleResponse>(settleHeader!)).toEqual(settled);
+  });
+
+  it('returns 400 when PAYMENT-SIGNATURE is malformed', async () => {
+    const app = new Hono();
+    app.use(
+      '/api/data',
+      x402Hono({
+        facilitator: fakeFacilitator({ isValid: true }, { success: true }),
+        accepts: [REQ],
+      }),
+    );
+    app.get('/api/data', (c) => c.json({ data: 'secret' }));
+
+    const res = await app.request('/api/data', {
+      headers: { [PAYMENT_SIGNATURE_HEADER]: 'not-base64-json' },
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Invalid payment payload/);
+  });
+
+  it('returns 500 when verify rejects', async () => {
+    const app = new Hono();
+    app.use(
+      '/api/data',
+      x402Hono({
+        facilitator: fakeFacilitator(
+          { isValid: false, invalidReason: 'bad sig' },
+          { success: true },
+        ),
+        accepts: [REQ],
+      }),
+    );
+    app.get('/api/data', (c) => c.json({ data: 'secret' }));
+
+    const res = await app.request('/api/data', {
+      headers: { [PAYMENT_SIGNATURE_HEADER]: encodePaymentPayload(buildPayload()) },
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('bad sig');
+  });
+
+  it('returns 500 with txHash + network when settle fails', async () => {
+    const app = new Hono();
+    app.use(
+      '/api/data',
+      x402Hono({
+        facilitator: fakeFacilitator(
+          { isValid: true },
+          {
+            success: false,
+            errorReason: 'insufficient balance',
+            transaction: '0xabc',
+            network: 'tron:nile',
+          },
+        ),
+        accepts: [REQ],
+      }),
+    );
+    app.get('/api/data', (c) => c.json({ data: 'secret' }));
+
+    const res = await app.request('/api/data', {
+      headers: { [PAYMENT_SIGNATURE_HEADER]: encodePaymentPayload(buildPayload()) },
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('insufficient balance');
+    expect(body.txHash).toBe('0xabc');
+    expect(body.network).toBe('tron:nile');
+  });
+});

--- a/typescript/packages/x402/src/middleware/hono.ts
+++ b/typescript/packages/x402/src/middleware/hono.ts
@@ -1,0 +1,78 @@
+/**
+ * Hono adapter for the x402 server middleware.
+ *
+ * Usage:
+ * ```ts
+ * import { Hono } from 'hono';
+ * import { FacilitatorClient, x402Hono } from '@bankofai/x402';
+ *
+ * const facilitator = new FacilitatorClient({ baseUrl: 'https://facilitator.example' });
+ * const app = new Hono();
+ *
+ * app.use(
+ *   '/api/llm-summary',
+ *   x402Hono({
+ *     facilitator,
+ *     accepts: [{
+ *       scheme: 'exact_permit',
+ *       network: 'tron:nile',
+ *       amount: '1000000',
+ *       asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+ *       payTo: 'TJWdoJ...',
+ *     }],
+ *   }),
+ * );
+ *
+ * app.get('/api/llm-summary', (c) => c.json({ summary: '...' }));
+ * ```
+ *
+ * Hono is imported via `peerDependencies`; consumers add it to their app.
+ */
+
+import type { Context, MiddlewareHandler, Next } from 'hono';
+
+import {
+  PAYMENT_SIGNATURE_HEADER,
+  processX402Request,
+  type X402MiddlewareConfig,
+} from './core.js';
+
+/**
+ * Build a Hono middleware that gates the wrapped route on x402 payment.
+ *
+ * Behavior:
+ * - No `PAYMENT-SIGNATURE` header → respond 402 with `PAYMENT-REQUIRED` header + body.
+ * - Malformed / mismatched payload → 400 JSON error.
+ * - Verify or settle failure → 500 JSON error.
+ * - Success → call `next()` and attach `PAYMENT-RESPONSE` header to the response.
+ */
+export function x402Hono(config: X402MiddlewareConfig): MiddlewareHandler {
+  return async (c: Context, next: Next) => {
+    const signature = c.req.header(PAYMENT_SIGNATURE_HEADER);
+    const decision = await processX402Request(signature, config);
+
+    switch (decision.kind) {
+      case 'paymentRequired': {
+        for (const [k, v] of Object.entries(decision.headers)) {
+          c.header(k, v);
+        }
+        return c.json(decision.paymentRequired, 402);
+      }
+      case 'invalid':
+        return c.json({ error: decision.reason }, 400);
+      case 'failed': {
+        const body: Record<string, unknown> = { error: decision.reason };
+        if (decision.transaction) body.txHash = decision.transaction;
+        if (decision.network) body.network = decision.network;
+        return c.json(body, 500);
+      }
+      case 'allow': {
+        await next();
+        for (const [k, v] of Object.entries(decision.headers)) {
+          c.header(k, v);
+        }
+        return;
+      }
+    }
+  };
+}

--- a/typescript/packages/x402/src/middleware/index.ts
+++ b/typescript/packages/x402/src/middleware/index.ts
@@ -6,13 +6,7 @@
  * - {@link processX402Request} — framework-agnostic core (build your own adapter)
  */
 
-export {
-  PAYMENT_REQUIRED_HEADER,
-  PAYMENT_RESPONSE_HEADER,
-  PAYMENT_SIGNATURE_HEADER,
-  processX402Request,
-  X402_VERSION,
-} from './core.js';
+export { processX402Request, X402_VERSION } from './core.js';
 export type { X402Decision, X402MiddlewareConfig } from './core.js';
 export { x402Hono } from './hono.js';
 export { x402Express } from './express.js';

--- a/typescript/packages/x402/src/middleware/index.ts
+++ b/typescript/packages/x402/src/middleware/index.ts
@@ -1,0 +1,18 @@
+/**
+ * x402 server middleware.
+ *
+ * - {@link x402Hono} — Hono adapter
+ * - {@link x402Express} — Express adapter
+ * - {@link processX402Request} — framework-agnostic core (build your own adapter)
+ */
+
+export {
+  PAYMENT_REQUIRED_HEADER,
+  PAYMENT_RESPONSE_HEADER,
+  PAYMENT_SIGNATURE_HEADER,
+  processX402Request,
+  X402_VERSION,
+} from './core.js';
+export type { X402Decision, X402MiddlewareConfig } from './core.js';
+export { x402Hono } from './hono.js';
+export { x402Express } from './express.js';

--- a/typescript/packages/x402/src/server/index.ts
+++ b/typescript/packages/x402/src/server/index.ts
@@ -1,0 +1,12 @@
+/**
+ * High-level x402 server API.
+ *
+ * For framework-agnostic protocol handling, see also `src/middleware/core.ts`.
+ * {@link X402Server} sits above that — it owns mechanism registration, price
+ * parsing, anti-tamper validation, and facilitator coordination.
+ */
+
+export { DefaultServerMechanism, X402Server } from './x402Server.js';
+export type { BuildPaymentRequiredOptions } from './x402Server.js';
+export { PAYMENT_ONLY } from './types.js';
+export type { ResourceConfig, ServerMechanism } from './types.js';

--- a/typescript/packages/x402/src/server/types.ts
+++ b/typescript/packages/x402/src/server/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-side type contracts for x402 SDK.
+ *
+ * - {@link ResourceConfig} — high-level config for a protected endpoint
+ * - {@link ServerMechanism} — per-(network, scheme) plugin used by {@link X402Server}
+ */
+
+import type { AssetAmount } from '../tokens.js';
+import type { PaymentPermit, PaymentRequirements } from '../types/index.js';
+
+/**
+ * Delivery modes for a protected resource. Only `PAYMENT_ONLY` ships today;
+ * future modes (e.g. `RECEIPT_REQUIRED`) plug in here.
+ */
+export const PAYMENT_ONLY = 'PAYMENT_ONLY';
+
+/**
+ * One protected endpoint's payment configuration.
+ *
+ * Mirrors Python `bankofai.x402.server.ResourceConfig`.
+ *
+ * @example
+ * ```ts
+ * const cfg: ResourceConfig = {
+ *   scheme: 'exact_permit',
+ *   network: 'tron:nile',
+ *   price: '1 USDT',
+ *   payTo: 'TJWdoJ...',
+ * };
+ * ```
+ */
+export interface ResourceConfig {
+  /** Payment scheme (`"exact"`, `"exact_permit"`, `"exact_gasfree"`, ...). */
+  scheme: string;
+  /** CAIP-2 network identifier (`"tron:nile"`, `"eip155:97"`, ...). */
+  network: string;
+  /** Human-readable price string parsed by {@link parsePrice} (e.g. `"1 USDT"`). */
+  price: string;
+  /** Recipient address. */
+  payTo: string;
+  /** Authorization validity window in seconds. Default 3600. */
+  validFor?: number;
+  /** Delivery mode. Default {@link PAYMENT_ONLY}. */
+  deliveryMode?: string;
+}
+
+/**
+ * Server-side mechanism interface.
+ *
+ * One instance per `(network, scheme)`. Implementations live in the
+ * mechanism packages (TRON / EVM / ...) and plug into {@link X402Server} via
+ * `register(network, mechanism)`.
+ *
+ * Mirrors Python `bankofai.x402.server.x402_server.ServerMechanism`.
+ */
+export interface ServerMechanism {
+  /** Scheme name (matches `ResourceConfig.scheme`). */
+  scheme(): string;
+  /**
+   * Resolve a `"<amount> <symbol>"` price string into a typed asset amount.
+   * The default mechanism implementation delegates to {@link parsePrice}.
+   */
+  parsePrice(price: string, network: string): Promise<AssetAmount>;
+  /**
+   * Hook to attach scheme-specific extra fields onto `PaymentRequirements`
+   * (e.g. `extra.name` / `extra.version` for permit tokens). Should return
+   * the requirements (possibly mutated, but a fresh object is preferred).
+   */
+  enhancePaymentRequirements(
+    requirements: PaymentRequirements,
+    deliveryMode: string,
+  ): Promise<PaymentRequirements>;
+  /** Sanity check on requirements (return false to reject the config). */
+  validatePaymentRequirements(requirements: PaymentRequirements): boolean;
+  /**
+   * Optional server-side signature verification before delegating to facilitator.
+   * Defense-in-depth — facilitator also verifies, but a misbehaving client / proxy
+   * should be rejected here too. Return `true` if the signature is valid.
+   *
+   * Implementations that don't perform local verification should be omitted entirely;
+   * {@link X402Server} treats an absent method as "trust the facilitator".
+   */
+  verifySignature?(
+    permit: PaymentPermit | null | undefined,
+    signature: string,
+    network: string,
+  ): Promise<boolean>;
+}

--- a/typescript/packages/x402/src/server/x402Server.test.ts
+++ b/typescript/packages/x402/src/server/x402Server.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for the high-level X402Server orchestration.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FacilitatorClient } from '../facilitator/client.js';
+import type {
+  FeeQuoteResponse,
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import { DefaultServerMechanism, X402Server } from './x402Server.js';
+import type { ResourceConfig, ServerMechanism } from './types.js';
+
+function fakeFacilitator(opts: {
+  verify?: VerifyResponse;
+  settle?: SettleResponse;
+  feeQuotes?: FeeQuoteResponse[];
+  facilitatorId?: string;
+} = {}): FacilitatorClient {
+  return {
+    facilitatorId: opts.facilitatorId ?? 'fac-test',
+    verify: vi.fn(async () => opts.verify ?? { isValid: true }),
+    settle: vi.fn(async () => opts.settle ?? { success: true, transaction: '0xtx' }),
+    feeQuote: vi.fn(async () => opts.feeQuotes ?? []),
+  } as unknown as FacilitatorClient;
+}
+
+describe('X402Server.buildPaymentRequirements', () => {
+  it('parses price strings into smallest-unit amounts', async () => {
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+
+    const reqs = await server.buildPaymentRequirements([
+      {
+        scheme: 'exact',
+        network: 'tron:mainnet',
+        price: '1 USDT',
+        payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+      },
+    ]);
+
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0]!.amount).toBe('1000000');
+    expect(reqs[0]!.asset).toBe('TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t');
+    expect(reqs[0]!.maxTimeoutSeconds).toBe(3600);
+  });
+
+  it('respects validFor override', async () => {
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+    const reqs = await server.buildPaymentRequirements([
+      {
+        scheme: 'exact',
+        network: 'tron:mainnet',
+        price: '1 USDT',
+        payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+        validFor: 60,
+      },
+    ]);
+    expect(reqs[0]!.maxTimeoutSeconds).toBe(60);
+  });
+
+  it('throws when no mechanism registered for (network, scheme)', async () => {
+    const server = new X402Server().setFacilitator(fakeFacilitator());
+    const cfg: ResourceConfig = {
+      scheme: 'exact',
+      network: 'tron:mainnet',
+      price: '1 USDT',
+      payTo: 'T...',
+    };
+    await expect(server.buildPaymentRequirements([cfg])).rejects.toThrow(
+      /No ServerMechanism registered/,
+    );
+  });
+
+  it('throws when facilitator is not set', async () => {
+    const server = new X402Server().register(
+      'tron:mainnet',
+      new DefaultServerMechanism('exact'),
+    );
+    await expect(
+      server.buildPaymentRequirements([
+        {
+          scheme: 'exact',
+          network: 'tron:mainnet',
+          price: '1 USDT',
+          payTo: 'T...',
+        },
+      ]),
+    ).rejects.toThrow(/Facilitator is not set/);
+  });
+
+  it('skips fee_quote for exact scheme (no facilitator fee needed)', async () => {
+    const facilitator = fakeFacilitator();
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(facilitator);
+
+    await server.buildPaymentRequirements([
+      {
+        scheme: 'exact',
+        network: 'tron:mainnet',
+        price: '1 USDT',
+        payTo: 'T...',
+      },
+    ]);
+
+    expect(facilitator.feeQuote).not.toHaveBeenCalled();
+  });
+
+  it('enriches permit-style requirements with facilitator fee', async () => {
+    const facilitator = fakeFacilitator({
+      feeQuotes: [
+        {
+          fee: { feeTo: 'TFee...', feeAmount: '100000' },
+          pricing: 'fixed',
+          scheme: 'exact_permit',
+          network: 'tron:mainnet',
+          asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        },
+      ],
+      facilitatorId: 'fac-1',
+    });
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact_permit'))
+      .setFacilitator(facilitator);
+
+    const reqs = await server.buildPaymentRequirements([
+      {
+        scheme: 'exact_permit',
+        network: 'tron:mainnet',
+        price: '1 USDT',
+        payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+      },
+    ]);
+
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0]!.extra?.fee).toMatchObject({
+      feeTo: 'TFee...',
+      feeAmount: '100000',
+      facilitatorId: 'fac-1',
+    });
+  });
+
+  it('drops permit requirements the facilitator cannot quote', async () => {
+    const facilitator = fakeFacilitator({ feeQuotes: [] });
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact_permit'))
+      .setFacilitator(facilitator);
+
+    const reqs = await server.buildPaymentRequirements([
+      {
+        scheme: 'exact_permit',
+        network: 'tron:mainnet',
+        price: '1 USDT',
+        payTo: 'T...',
+      },
+    ]);
+    expect(reqs).toHaveLength(0);
+  });
+});
+
+describe('X402Server.createPaymentRequiredResponse', () => {
+  it('emits x402Version=2 and paymentPermitContext meta', () => {
+    const server = new X402Server();
+    const reqs: PaymentRequirements[] = [
+      {
+        scheme: 'exact_permit',
+        network: 'tron:mainnet',
+        amount: '1000000',
+        asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        payTo: 'TJWdoJ...',
+      },
+    ];
+    const response = server.createPaymentRequiredResponse(reqs);
+    expect(response.x402Version).toBe(2);
+    expect(response.accepts).toBe(reqs);
+    expect(response.extensions?.paymentPermitContext?.meta.paymentId).toMatch(/^0x[0-9a-f]{32}$/);
+    expect(response.extensions?.paymentPermitContext?.meta.kind).toBe('PAYMENT_ONLY');
+  });
+
+  it('respects user-supplied paymentId / validity window', () => {
+    const server = new X402Server();
+    const response = server.createPaymentRequiredResponse([], {
+      paymentId: '0x' + 'aa'.repeat(16),
+      validAfter: 1700000000,
+      validBefore: 1700003600,
+    });
+    expect(response.extensions?.paymentPermitContext?.meta).toMatchObject({
+      paymentId: '0x' + 'aa'.repeat(16),
+      validAfter: 1700000000,
+      validBefore: 1700003600,
+    });
+  });
+});
+
+describe('X402Server.verifyPayment / settlePayment', () => {
+  const baseReq: PaymentRequirements = {
+    scheme: 'exact_permit',
+    network: 'tron:mainnet',
+    amount: '1000000',
+    asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+    payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+  };
+
+  function makePayload(): PaymentPayload {
+    return {
+      x402Version: 2,
+      accepted: baseReq,
+      payload: {
+        signature: '0x' + 'aa'.repeat(65),
+        paymentPermit: {
+          meta: {
+            kind: 'PAYMENT_ONLY',
+            paymentId: '0x' + '11'.repeat(16),
+            nonce: '0',
+            validAfter: 0,
+            validBefore: 9_999_999_999,
+          },
+          buyer: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+          caller: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+          payment: {
+            payToken: baseReq.asset,
+            payAmount: baseReq.amount,
+            payTo: baseReq.payTo,
+          },
+          fee: { feeTo: 'TFee', feeAmount: '0' },
+        },
+      },
+    } as PaymentPayload;
+  }
+
+  it('verifyPayment delegates to facilitator after anti-tamper passes', async () => {
+    const facilitator = fakeFacilitator({ verify: { isValid: true } });
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact_permit'))
+      .setFacilitator(facilitator);
+
+    const result = await server.verifyPayment(makePayload(), baseReq);
+    expect(result.isValid).toBe(true);
+    expect(facilitator.verify).toHaveBeenCalledOnce();
+  });
+
+  it('verifyPayment rejects payload_mismatch when asset is wrong', async () => {
+    const facilitator = fakeFacilitator();
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact_permit'))
+      .setFacilitator(facilitator);
+
+    const payload = makePayload();
+    payload.payload.paymentPermit!.payment.payToken = 'WRONG_ASSET';
+
+    const result = await server.verifyPayment(payload, baseReq);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe('payload_mismatch');
+    expect(facilitator.verify).not.toHaveBeenCalled();
+  });
+
+  it('verifyPayment returns no_facilitator when facilitator unset', async () => {
+    const server = new X402Server().register(
+      'tron:mainnet',
+      new DefaultServerMechanism('exact_permit'),
+    );
+    const result = await server.verifyPayment(makePayload(), baseReq);
+    expect(result).toEqual({ isValid: false, invalidReason: 'no_facilitator' });
+  });
+
+  it('verifyPayment runs mechanism.verifySignature when present', async () => {
+    const verifySignature = vi.fn(async () => false);
+    const base = new DefaultServerMechanism('exact_permit');
+    const customMech: ServerMechanism = {
+      scheme: () => base.scheme(),
+      parsePrice: (p, n) => base.parsePrice(p, n),
+      enhancePaymentRequirements: (r, d) => base.enhancePaymentRequirements(r, d),
+      validatePaymentRequirements: (r) => base.validatePaymentRequirements(r),
+      verifySignature,
+    };
+    const server = new X402Server()
+      .register('tron:mainnet', customMech)
+      .setFacilitator(fakeFacilitator());
+
+    const result = await server.verifyPayment(makePayload(), baseReq);
+    expect(result).toEqual({ isValid: false, invalidReason: 'invalid_signature_server' });
+    expect(verifySignature).toHaveBeenCalledOnce();
+  });
+
+  it('settlePayment returns no_facilitator without facilitator', async () => {
+    const server = new X402Server();
+    const result = await server.settlePayment(makePayload(), baseReq);
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe('no_facilitator');
+    expect(result.network).toBe('tron:mainnet');
+  });
+
+  it('settlePayment delegates to facilitator', async () => {
+    const facilitator = fakeFacilitator({
+      settle: { success: true, transaction: '0xabc', network: 'tron:mainnet' },
+    });
+    const server = new X402Server().setFacilitator(facilitator);
+    const result = await server.settlePayment(makePayload(), baseReq);
+    expect(result.success).toBe(true);
+    expect(result.transaction).toBe('0xabc');
+  });
+});
+
+describe('X402Server anti-tamper for exact scheme', () => {
+  const exactReq: PaymentRequirements = {
+    scheme: 'exact',
+    network: 'tron:mainnet',
+    amount: '1000000',
+    asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+    payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+  };
+
+  function exactPayload(overrides: Partial<NonNullable<PaymentPayload['payload']['authorization']>> = {}): PaymentPayload {
+    const now = Math.floor(Date.now() / 1000);
+    return {
+      x402Version: 2,
+      accepted: exactReq,
+      payload: {
+        signature: '0x' + 'aa'.repeat(65),
+        authorization: {
+          from: 'TFrom',
+          to: exactReq.payTo,
+          value: exactReq.amount,
+          validAfter: String(now - 10),
+          validBefore: String(now + 600),
+          nonce: '0x' + '11'.repeat(32),
+          ...overrides,
+        },
+      },
+    } as PaymentPayload;
+  }
+
+  it('passes valid exact authorization', async () => {
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+    const result = await server.verifyPayment(exactPayload(), exactReq);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects when authorization value < amount', async () => {
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+    const result = await server.verifyPayment(exactPayload({ value: '500000' }), exactReq);
+    expect(result.invalidReason).toBe('payload_mismatch');
+  });
+
+  it('rejects when authorization.to !== payTo', async () => {
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+    const result = await server.verifyPayment(exactPayload({ to: 'TWrong' }), exactReq);
+    expect(result.invalidReason).toBe('payload_mismatch');
+  });
+
+  it('rejects expired authorization (validBefore < now)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+    const result = await server.verifyPayment(
+      exactPayload({ validBefore: String(now - 60) }),
+      exactReq,
+    );
+    expect(result.invalidReason).toBe('payload_mismatch');
+  });
+
+  it('rejects not-yet-valid authorization (validAfter > now)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const server = new X402Server()
+      .register('tron:mainnet', new DefaultServerMechanism('exact'))
+      .setFacilitator(fakeFacilitator());
+    const result = await server.verifyPayment(
+      exactPayload({ validAfter: String(now + 600) }),
+      exactReq,
+    );
+    expect(result.invalidReason).toBe('payload_mismatch');
+  });
+});

--- a/typescript/packages/x402/src/server/x402Server.ts
+++ b/typescript/packages/x402/src/server/x402Server.ts
@@ -1,0 +1,381 @@
+/**
+ * X402Server — TypeScript port of `bankofai.x402.server.X402Server`.
+ *
+ * High-level server orchestration:
+ * - Registry of {@link ServerMechanism}s keyed by `(network, scheme)`
+ * - Build {@link PaymentRequirements} from {@link ResourceConfig} via `parsePrice`
+ *   + optional facilitator `feeQuote` enrichment for permit-style schemes
+ * - Anti-tamper validation of incoming `PaymentPayload` against server's
+ *   original requirements
+ * - Delegates `/verify` and `/settle` to a {@link FacilitatorClient}
+ *
+ * This sits **above** the framework-agnostic {@link processX402Request} core
+ * (see `src/middleware/core.ts`). Framework middleware (Hono / Express)
+ * can be wired against either:
+ * - Raw `accepts[]` + `FacilitatorClient` (lower-level, `processX402Request`)
+ * - `X402Server` + `ResourceConfig[]` (higher-level, this file)
+ */
+
+import { getAddress, isAddress } from 'viem';
+
+import type { FacilitatorClient } from '../facilitator/client.js';
+import { parsePrice } from '../tokens.js';
+import type {
+  PaymentPayload,
+  PaymentRequired,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from '../types/index.js';
+import { generatePaymentId } from '../utils/index.js';
+import { PAYMENT_ONLY, type ResourceConfig, type ServerMechanism } from './types.js';
+
+/** Resource info echoed back in the 402 response body. */
+export interface ResourceInfo {
+  url?: string;
+  description?: string;
+  mimeType?: string;
+}
+
+/** Optional overrides when building the 402 response. */
+export interface BuildPaymentRequiredOptions {
+  resource?: ResourceInfo;
+  paymentId?: string;
+  nonce?: string;
+  validAfter?: number;
+  validBefore?: number;
+}
+
+/**
+ * Default {@link ServerMechanism} that delegates `parsePrice` to the token
+ * registry and applies a no-op `enhancePaymentRequirements`. Useful when a
+ * chain/scheme needs no scheme-specific enrichment.
+ */
+export class DefaultServerMechanism implements ServerMechanism {
+  constructor(private readonly schemeName: string) {}
+
+  scheme(): string {
+    return this.schemeName;
+  }
+
+  async parsePrice(price: string, network: string) {
+    return parsePrice(price, network);
+  }
+
+  async enhancePaymentRequirements(
+    requirements: PaymentRequirements,
+    _deliveryMode: string,
+  ): Promise<PaymentRequirements> {
+    return requirements;
+  }
+
+  validatePaymentRequirements(_requirements: PaymentRequirements): boolean {
+    return true;
+  }
+}
+
+/**
+ * Core server orchestration. One instance per resource server.
+ *
+ * @example
+ * ```ts
+ * const facilitator = new FacilitatorClient({ baseUrl: 'https://fac.example' });
+ * const server = new X402Server()
+ *   .register('tron:nile', new DefaultServerMechanism('exact_permit'))
+ *   .setFacilitator(facilitator);
+ *
+ * const accepts = await server.buildPaymentRequirements([
+ *   { scheme: 'exact_permit', network: 'tron:nile', price: '1 USDT', payTo: 'T...' },
+ * ]);
+ * const challenge = server.createPaymentRequiredResponse(accepts);
+ * ```
+ */
+export class X402Server {
+  /** network → scheme → mechanism */
+  private readonly mechanisms = new Map<string, Map<string, ServerMechanism>>();
+  private facilitator: FacilitatorClient | null = null;
+
+  /** Register a {@link ServerMechanism} for one network. Chainable. */
+  register(network: string, mechanism: ServerMechanism): this {
+    const scheme = mechanism.scheme();
+    let byScheme = this.mechanisms.get(network);
+    if (!byScheme) {
+      byScheme = new Map<string, ServerMechanism>();
+      this.mechanisms.set(network, byScheme);
+    }
+    byScheme.set(scheme, mechanism);
+    return this;
+  }
+
+  /** Set the facilitator client. Required before {@link verifyPayment} / {@link settlePayment}. */
+  setFacilitator(client: FacilitatorClient): this {
+    this.facilitator = client;
+    return this;
+  }
+
+  /**
+   * Turn a list of {@link ResourceConfig} into ready-to-serve {@link PaymentRequirements}.
+   *
+   * Pipeline per config:
+   * 1. Find mechanism by `(network, scheme)`; throw if not registered.
+   * 2. Parse `price` → asset + amount via mechanism.
+   * 3. Build initial `PaymentRequirements`.
+   * 4. Let mechanism `enhancePaymentRequirements` attach extras (token name/version, etc.).
+   * 5. Normalize EVM addresses via checksum.
+   *
+   * If a facilitator is configured, permit-style requirements (`scheme !== 'exact'`)
+   * get enriched with `extra.fee` from `/fee/quote`. Unsupported (network, scheme, asset)
+   * tuples returned by the facilitator are silently dropped from the result.
+   *
+   * Mirrors Python `X402Server.build_payment_requirements`.
+   */
+  async buildPaymentRequirements(
+    configs: ResourceConfig[],
+  ): Promise<PaymentRequirements[]> {
+    const built: PaymentRequirements[] = [];
+    for (const config of configs) {
+      const mechanism = this.findMechanism(config.network, config.scheme);
+      if (!mechanism) {
+        throw new Error(
+          `No ServerMechanism registered for network=${config.network}, scheme=${config.scheme}`,
+        );
+      }
+
+      const assetInfo = await mechanism.parsePrice(config.price, config.network);
+
+      let requirements: PaymentRequirements = {
+        scheme: config.scheme,
+        network: config.network,
+        amount: assetInfo.amount,
+        asset: assetInfo.asset,
+        payTo: config.payTo,
+        maxTimeoutSeconds: config.validFor ?? 3600,
+      };
+      requirements = await mechanism.enhancePaymentRequirements(
+        requirements,
+        config.deliveryMode ?? PAYMENT_ONLY,
+      );
+      requirements = this.normalizeEvmRequirements(requirements);
+      built.push(requirements);
+    }
+
+    if (!this.facilitator) {
+      throw new Error('Facilitator is not set (call setFacilitator first)');
+    }
+
+    // Split: exact doesn't need fee quote; everything else (permit-style) does.
+    const exactReqs = built.filter((r) => r.scheme === 'exact');
+    const permitReqs = built.filter((r) => r.scheme !== 'exact');
+
+    const supported: PaymentRequirements[] = [...exactReqs];
+    if (permitReqs.length > 0) {
+      const quotes = await this.facilitator.feeQuote(permitReqs);
+      const quoteMap = new Map<string, (typeof quotes)[number]>();
+      for (const q of quotes) {
+        quoteMap.set(`${q.scheme}|${q.network}|${q.asset}`, q);
+      }
+      for (const req of permitReqs) {
+        const quote = quoteMap.get(`${req.scheme}|${req.network}|${req.asset}`);
+        if (!quote) {
+          // Facilitator can't quote this (unsupported token / scheme). Silently skip.
+          continue;
+        }
+        const enriched: PaymentRequirements = {
+          ...req,
+          extra: {
+            ...(req.extra ?? {}),
+            fee: {
+              ...quote.fee,
+              facilitatorId: this.facilitator.facilitatorId,
+            },
+          },
+        };
+        supported.push(this.normalizeEvmRequirements(enriched));
+      }
+    }
+    return supported;
+  }
+
+  /**
+   * Build the 402 PaymentRequired challenge body. The facilitator is not
+   * consulted here — the caller has already obtained `requirements` via
+   * {@link buildPaymentRequirements} or constructed them by hand.
+   */
+  createPaymentRequiredResponse(
+    requirements: PaymentRequirements[],
+    options: BuildPaymentRequiredOptions = {},
+  ): PaymentRequired {
+    const now = Math.floor(Date.now() / 1000);
+    const validBefore = options.validBefore ?? now + 3600;
+    const validAfter = options.validAfter ?? now;
+
+    return {
+      x402Version: 2,
+      error: 'Payment required',
+      ...(options.resource ? { resource: options.resource } : {}),
+      accepts: requirements,
+      extensions: {
+        paymentPermitContext: {
+          meta: {
+            kind: PAYMENT_ONLY,
+            paymentId: options.paymentId ?? generatePaymentId(),
+            nonce: options.nonce ?? generateNonce(),
+            validAfter,
+            validBefore,
+          },
+        },
+      },
+    } as PaymentRequired;
+  }
+
+  /**
+   * Anti-tamper validation + optional server-side signature check, then
+   * delegate to the facilitator. Mirrors Python `verify_payment`.
+   */
+  async verifyPayment(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    if (!this.validatePayloadMatchesRequirements(payload, requirements)) {
+      return { isValid: false, invalidReason: 'payload_mismatch' };
+    }
+
+    const mechanism = this.findMechanism(requirements.network, requirements.scheme);
+    if (mechanism?.verifySignature) {
+      const permit = payload.payload.paymentPermit ?? null;
+      const signature = payload.payload.signature;
+      const ok = await mechanism.verifySignature(permit, signature, requirements.network);
+      if (!ok) {
+        return { isValid: false, invalidReason: 'invalid_signature_server' };
+      }
+    }
+
+    if (!this.facilitator) {
+      return { isValid: false, invalidReason: 'no_facilitator' };
+    }
+    return this.facilitator.verify(payload, requirements);
+  }
+
+  /** Delegate settlement to the facilitator. Mirrors Python `settle_payment`. */
+  async settlePayment(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    if (!this.facilitator) {
+      return {
+        success: false,
+        network: requirements.network,
+        errorReason: 'no_facilitator',
+      };
+    }
+    return this.facilitator.settle(payload, requirements);
+  }
+
+  /**
+   * Anti-tampering: the client's `payload.accepted` must match server's
+   * canonical `requirements`, and the embedded authorization / permit must
+   * point at the right asset / payTo / amount.
+   *
+   * Two flavors:
+   * - `exact` (ERC-3009): inspects `payload.payload.authorization`
+   * - other (permit-style): inspects `payload.payload.paymentPermit`
+   */
+  private validatePayloadMatchesRequirements(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): boolean {
+    if (requirements.scheme === 'exact') {
+      const auth =
+        payload.payload.authorization ??
+        ((payload.extensions ?? {})['transferAuthorization'] as
+          | PaymentPayload['payload']['authorization']
+          | undefined);
+      if (!auth) return false;
+
+      if (payload.accepted) {
+        if (payload.accepted.asset !== requirements.asset) return false;
+        if (payload.accepted.network !== requirements.network) return false;
+      }
+
+      try {
+        if (BigInt(String(auth.value)) < BigInt(requirements.amount)) return false;
+      } catch {
+        return false;
+      }
+      if (String(auth.to).toLowerCase() !== String(requirements.payTo).toLowerCase()) {
+        return false;
+      }
+
+      const now = Math.floor(Date.now() / 1000);
+      try {
+        const validBefore = BigInt(String(auth.validBefore ?? '0'));
+        const validAfter = BigInt(String(auth.validAfter ?? now));
+        if (validBefore < BigInt(now)) return false;
+        if (validAfter > BigInt(now)) return false;
+      } catch {
+        return false;
+      }
+      return true;
+    }
+
+    const permit = payload.payload.paymentPermit;
+    if (!permit) return false;
+    if (permit.payment.payToken !== requirements.asset) return false;
+    if (permit.payment.payTo !== requirements.payTo) return false;
+    try {
+      if (BigInt(permit.payment.payAmount) < BigInt(requirements.amount)) return false;
+    } catch {
+      return false;
+    }
+    return true;
+  }
+
+  private findMechanism(network: string, scheme: string): ServerMechanism | null {
+    return this.mechanisms.get(network)?.get(scheme) ?? null;
+  }
+
+  private normalizeEvmRequirements(reqs: PaymentRequirements): PaymentRequirements {
+    if (!reqs.network.startsWith('eip155:')) {
+      return reqs;
+    }
+    return {
+      ...reqs,
+      asset: checksumOrThrow(reqs.asset, 'asset'),
+      payTo: checksumOrThrow(reqs.payTo, 'payTo'),
+      extra: reqs.extra
+        ? {
+            ...reqs.extra,
+            ...(reqs.extra.fee
+              ? {
+                  fee: {
+                    ...reqs.extra.fee,
+                    feeTo: checksumOrThrow(reqs.extra.fee.feeTo, 'extra.fee.feeTo'),
+                    ...(reqs.extra.fee.caller
+                      ? { caller: checksumOrThrow(reqs.extra.fee.caller, 'extra.fee.caller') }
+                      : {}),
+                  },
+                }
+              : {}),
+          }
+        : reqs.extra,
+    };
+  }
+}
+
+function checksumOrThrow(address: string, field: string): string {
+  if (!isAddress(address, { strict: false })) {
+    throw new Error(`Invalid EVM address for ${field}: ${address}`);
+  }
+  return getAddress(address);
+}
+
+function generateNonce(): string {
+  // 16 random bytes, decimal-encoded — matches Python's str(uuid.uuid4().int) shape.
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let nonce = 0n;
+  for (const byte of bytes) {
+    nonce = (nonce << 8n) | BigInt(byte);
+  }
+  return nonce.toString();
+}

--- a/typescript/packages/x402/src/signers/facilitator/base.ts
+++ b/typescript/packages/x402/src/signers/facilitator/base.ts
@@ -1,0 +1,95 @@
+/**
+ * FacilitatorSigner — abstract base interface for facilitator-side signers.
+ *
+ * Mirrors Python `bankofai.x402.signers.facilitator.base.FacilitatorSigner`.
+ *
+ * Responsible for verifying signatures and executing on-chain transactions
+ * on behalf of the facilitator (settle path).
+ */
+
+export interface TypedDataDomain {
+  name?: string;
+  version?: string;
+  chainId?: number;
+  verifyingContract?: string;
+  salt?: string;
+}
+
+export type TypedDataTypes = Record<
+  string,
+  ReadonlyArray<{ name: string; type: string }>
+>;
+
+export interface TransactionReceipt {
+  hash: string;
+  blockNumber: string;
+  status: 'confirmed' | 'failed';
+}
+
+export abstract class FacilitatorSigner {
+  /** Facilitator's account address (Base58 on TRON, hex on EVM). */
+  abstract getAddress(): string;
+
+  /**
+   * Verify EIP-712 / TIP-712 typed-data signature.
+   *
+   * @param address Expected signer address (Base58 on TRON; the impl normalizes).
+   * @param domain EIP-712 domain.
+   * @param types Type definitions (the impl injects `EIP712Domain` if needed).
+   * @param message Signed message.
+   * @param signature Hex signature (with or without `0x`).
+   * @param primaryType Root type name.
+   */
+  abstract verifyTypedData(
+    address: string,
+    domain: TypedDataDomain,
+    types: TypedDataTypes,
+    message: Record<string, unknown>,
+    signature: string,
+    primaryType: string,
+  ): Promise<boolean>;
+
+  /**
+   * Execute a contract write transaction. Returns the tx hash, or `null` on
+   * broadcast failure (no exception — callers should treat null as failure).
+   *
+   * @param contractAddress Contract address (Base58 on TRON, hex on EVM).
+   * @param abi Contract ABI (JSON string or array).
+   * @param method Method name.
+   * @param args Method arguments. For tuple structs, pass nested arrays/objects.
+   * @param network Network identifier (e.g. `tron:nile`, `eip155:97`).
+   */
+  abstract writeContract(
+    contractAddress: string,
+    abi: string | unknown[],
+    method: string,
+    args: unknown[],
+    network: string,
+  ): Promise<string | null>;
+
+  /**
+   * Check ERC20/TRC20 token balance for an address.
+   *
+   * @param token Token contract address.
+   * @param network Network identifier.
+   * @param address Optional address (defaults to signer's address).
+   */
+  abstract checkBalance(
+    token: string,
+    network: string,
+    address?: string,
+  ): Promise<bigint>;
+
+  /**
+   * Wait for transaction confirmation (poll receipt).
+   *
+   * @param txHash Transaction hash.
+   * @param network Network identifier.
+   * @param timeoutMs Timeout in milliseconds (default 120s).
+   */
+  abstract waitForTransactionReceipt(
+    txHash: string,
+    network: string,
+    timeoutMs?: number,
+  ): Promise<TransactionReceipt>;
+}

--- a/typescript/packages/x402/src/signers/facilitator/evmSigner.ts
+++ b/typescript/packages/x402/src/signers/facilitator/evmSigner.ts
@@ -1,0 +1,204 @@
+/**
+ * EvmFacilitatorSigner — EVM facilitator signer (EIP-712 verify + contract write).
+ *
+ * Mirrors Python `bankofai.x402.signers.facilitator.evm_signer.EvmFacilitatorSigner`.
+ *
+ * Uses `viem` for everything:
+ * - `recoverTypedDataAddress` for verify
+ * - `PublicClient.simulateContract` + `wallet.signTransaction` + `sendRawTransaction` for write
+ * - `PublicClient.waitForTransactionReceipt` for receipt polling
+ */
+
+import {
+  createPublicClient,
+  encodeFunctionData,
+  http,
+  recoverTypedDataAddress,
+} from 'viem';
+import type {
+  Abi,
+  Hex,
+  PublicClient,
+  TypedDataDomain as ViemTypedDataDomain,
+} from 'viem';
+import { resolveWalletProvider } from '@bankofai/agent-wallet';
+
+import {
+  FacilitatorSigner,
+  type TypedDataDomain,
+  type TypedDataTypes,
+  type TransactionReceipt,
+} from './base.js';
+import { ERC20_ABI } from '../../abi.js';
+import { getChainId, resolveRpcUrl } from '../../config.js';
+import type { AgentWallet } from '../signer.js';
+
+export class EvmFacilitatorSigner extends FacilitatorSigner {
+  private wallet: AgentWallet;
+  private address: Hex = '0x0000000000000000000000000000000000000000';
+  private clients: Map<number, PublicClient> = new Map();
+
+  constructor(wallet: AgentWallet) {
+    super();
+    this.wallet = wallet;
+  }
+
+  static async create(): Promise<EvmFacilitatorSigner> {
+    const provider = resolveWalletProvider({ network: 'eip155' });
+    const wallet = await provider.getActiveWallet();
+    const signer = new EvmFacilitatorSigner(wallet as unknown as AgentWallet);
+    signer.setAddress((await wallet.getAddress()) as Hex);
+    return signer;
+  }
+
+  setAddress(address: Hex): void {
+    this.address = address;
+  }
+
+  getAddress(): string {
+    return this.address;
+  }
+
+  private getPublicClient(network: string): PublicClient {
+    const chainId = getChainId(network);
+    let client = this.clients.get(chainId);
+    if (!client) {
+      const rpcUrl = resolveRpcUrl(network);
+      if (!rpcUrl) {
+        throw new Error(`No RPC URL configured for ${network}`);
+      }
+      client = createPublicClient({ transport: http(rpcUrl) });
+      this.clients.set(chainId, client);
+    }
+    return client;
+  }
+
+  async verifyTypedData(
+    address: string,
+    domain: TypedDataDomain,
+    types: TypedDataTypes,
+    message: Record<string, unknown>,
+    signature: string,
+    primaryType: string,
+  ): Promise<boolean> {
+    try {
+      const viemDomain: ViemTypedDataDomain = {
+        name: domain.name,
+        version: domain.version,
+        chainId: domain.chainId,
+        verifyingContract: domain.verifyingContract as Hex | undefined,
+        ...(domain.salt ? { salt: domain.salt as `0x${string}` } : {}),
+      };
+      const typesNoDomain: TypedDataTypes = { ...types };
+      delete (typesNoDomain as Record<string, unknown>)['EIP712Domain'];
+
+      const sigBytes = signature.startsWith('0x')
+        ? (signature as Hex)
+        : (`0x${signature}` as Hex);
+
+      const recovered = await recoverTypedDataAddress({
+        domain: viemDomain,
+        types: typesNoDomain as Record<
+          string,
+          ReadonlyArray<{ name: string; type: string }>
+        >,
+        primaryType,
+        message,
+        signature: sigBytes,
+      });
+      return recovered.toLowerCase() === address.toLowerCase();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[EvmFacilitatorSigner] verifyTypedData failed:', err);
+      return false;
+    }
+  }
+
+  async writeContract(
+    contractAddress: string,
+    abi: string | unknown[],
+    method: string,
+    args: unknown[],
+    network: string,
+  ): Promise<string | null> {
+    try {
+      const client = this.getPublicClient(network);
+      const chainId = getChainId(network);
+
+      const abiArray = (typeof abi === 'string' ? JSON.parse(abi) : abi) as Abi;
+
+      const data = encodeFunctionData({
+        abi: abiArray,
+        functionName: method,
+        args,
+      });
+
+      const nonce = await client.getTransactionCount({ address: this.address });
+      const gasPrice = await client.getGasPrice();
+      const gas = await client.estimateGas({
+        account: this.address,
+        to: contractAddress as Hex,
+        data,
+      });
+
+      const tx = {
+        from: this.address,
+        to: contractAddress,
+        data,
+        nonce,
+        gas: Number(gas),
+        gasPrice: Number(gasPrice),
+        chainId,
+      };
+
+      const signedTxHex = await this.wallet.signTransaction(tx);
+      const hash = await client.sendRawTransaction({
+        serializedTransaction: `0x${signedTxHex.replace(/^0x/, '')}` as Hex,
+      });
+      return hash;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[EvmFacilitatorSigner] writeContract failed:', err);
+      return null;
+    }
+  }
+
+  async checkBalance(
+    token: string,
+    network: string,
+    address?: string,
+  ): Promise<bigint> {
+    try {
+      const client = this.getPublicClient(network);
+      const target = (address ?? this.address) as Hex;
+      const balance = await client.readContract({
+        address: token as Hex,
+        abi: ERC20_ABI,
+        functionName: 'balanceOf',
+        args: [target],
+      });
+      return BigInt(balance as bigint);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[EvmFacilitatorSigner] checkBalance failed for ${token}:`, err);
+      return BigInt(0);
+    }
+  }
+
+  async waitForTransactionReceipt(
+    txHash: string,
+    network: string,
+    timeoutMs: number = 120_000,
+  ): Promise<TransactionReceipt> {
+    const client = this.getPublicClient(network);
+    const receipt = await client.waitForTransactionReceipt({
+      hash: txHash as Hex,
+      timeout: timeoutMs,
+    });
+    return {
+      hash: txHash,
+      blockNumber: String(receipt.blockNumber),
+      status: receipt.status === 'success' ? 'confirmed' : 'failed',
+    };
+  }
+}

--- a/typescript/packages/x402/src/signers/facilitator/tronSigner.ts
+++ b/typescript/packages/x402/src/signers/facilitator/tronSigner.ts
@@ -1,0 +1,360 @@
+/**
+ * TronFacilitatorSigner — TRON facilitator signer (TIP-712 verify + contract write).
+ *
+ * Mirrors Python `bankofai.x402.signers.facilitator.tron_signer.TronFacilitatorSigner`.
+ *
+ * Uses:
+ * - `tronweb` v6 for transaction building, signing wrap, broadcasting, receipt polling
+ * - `viem` for cross-chain EIP-712 signature recovery (TRON TIP-712 is structurally
+ *   identical to EIP-712 once addresses are normalized to 0x hex)
+ * - `@bankofai/agent-wallet` for the signing wallet abstraction
+ */
+
+import { recoverTypedDataAddress } from 'viem';
+import type { TypedDataDomain as ViemTypedDataDomain } from 'viem';
+import { resolveWalletProvider } from '@bankofai/agent-wallet';
+import { TronWeb as TronWebClass } from 'tronweb';
+
+import {
+  FacilitatorSigner,
+  type TypedDataDomain,
+  type TypedDataTypes,
+  type TransactionReceipt,
+} from './base.js';
+import type { TronWeb } from '../types.js';
+import { toEvmHex } from '../../address.js';
+import { getTronRpcUrl } from '../../config.js';
+import type { AgentWallet } from '../signer.js';
+
+/**
+ * Buffer-like check that works in both Node and bundled environments without
+ * requiring `Buffer` to be in the global scope.
+ */
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error(`Invalid hex string length: ${clean.length}`);
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * TRON facilitator signer.
+ *
+ * The wallet is responsible for signing transactions; the signer wraps tronweb
+ * for building and broadcasting them. For verify, we use viem's typed-data
+ * recovery directly — it does not need the wallet.
+ */
+export class TronFacilitatorSigner extends FacilitatorSigner {
+  private wallet: AgentWallet;
+  private address: string = ''; // Base58 format
+  private tronWebInstances: Map<string, TronWeb> = new Map();
+  /**
+   * Raw private key (hex, no `0x`) read from `TRON_FACILITATOR_PRIVATE_KEY`
+   * or `TRON_PRIVATE_KEY`. When present, signs transactions directly via
+   * `tronweb.trx.sign(tx, privateKey)` — mirrors Python's tronpy direct-sign
+   * path that bypasses agent-wallet (because agent-wallet's TRON sign_transaction
+   * round-trip can drift the tx's raw_data and invalidate the txID/signature).
+   */
+  private privateKey: string | null = null;
+  /**
+   * TRON permission id used when building transactions.
+   * Default `2` = active permission (required for multi-sig facilitator
+   * accounts with owner threshold > 1). Override via `TRON_PERMISSION_ID` env.
+   */
+  private permissionId: number = 2;
+
+  constructor(wallet: AgentWallet) {
+    super();
+    this.wallet = wallet;
+    if (typeof process !== 'undefined') {
+      const pk =
+        process.env?.TRON_FACILITATOR_PRIVATE_KEY ??
+        process.env?.TRON_PRIVATE_KEY ??
+        null;
+      if (pk) {
+        this.privateKey = pk.startsWith('0x') ? pk.slice(2) : pk;
+      }
+      const permId = process.env?.TRON_PERMISSION_ID;
+      if (permId) {
+        const parsed = parseInt(permId, 10);
+        if (!isNaN(parsed)) this.permissionId = parsed;
+      }
+    }
+  }
+
+  /** Async factory: resolve active agent wallet and create signer. */
+  static async create(): Promise<TronFacilitatorSigner> {
+    const provider = resolveWalletProvider({ network: 'tron' });
+    const wallet = await provider.getActiveWallet();
+    const signer = new TronFacilitatorSigner(wallet as unknown as AgentWallet);
+    signer.setAddress(await wallet.getAddress());
+    return signer;
+  }
+
+  setAddress(address: string): void {
+    this.address = address;
+  }
+
+  getAddress(): string {
+    if (!this.address) {
+      throw new Error('TronFacilitatorSigner address has not been initialized');
+    }
+    return this.address;
+  }
+
+  /**
+   * Extract signature hex from agent-wallet's signTransaction result.
+   * agent-wallet TronWallet returns a JSON string with the full signed tx.
+   */
+  private extractTronSignature(result: string): string {
+    if (typeof result === 'string' && result.trim().startsWith('{')) {
+      const signed = JSON.parse(result);
+      const sigs = signed.signature;
+      if (!Array.isArray(sigs) || sigs.length === 0) {
+        throw new Error('Wallet returned signed tx without signature');
+      }
+      return sigs[0];
+    }
+    return result;
+  }
+
+  /** Get or create a TronWeb instance for the given network. */
+  private getTronWeb(network: string): TronWeb {
+    const host = getTronRpcUrl(network);
+    if (!host) {
+      throw new Error(`No TRON RPC URL configured for network: ${network}`);
+    }
+    let tw = this.tronWebInstances.get(host);
+    if (!tw) {
+      const apiKey =
+        typeof process !== 'undefined' ? process.env?.TRON_GRID_API_KEY : undefined;
+      const headers = apiKey ? { 'TRON-PRO-API-KEY': apiKey } : undefined;
+      // Dummy private key — facilitator signing routes via wallet.signTransaction,
+      // not via TronWeb's defaultPrivateKey.
+      const dummyKey =
+        '0000000000000000000000000000000000000000000000000000000000000001';
+      tw = new TronWebClass({
+        fullHost: host,
+        privateKey: dummyKey,
+        headers,
+      }) as unknown as TronWeb;
+      this.tronWebInstances.set(host, tw);
+    }
+    return tw;
+  }
+
+  /**
+   * Verify EIP-712 / TIP-712 signature.
+   *
+   * Strategy: convert all TRON Base58 addresses in domain.verifyingContract
+   * and the message to 0x EVM hex, then use viem's `recoverTypedDataAddress`
+   * to recover the signer. Compare against the expected address (also
+   * converted to hex).
+   *
+   * Domain types are NOT included in the `types` arg here — viem injects
+   * `EIP712Domain` automatically.
+   */
+  async verifyTypedData(
+    address: string,
+    domain: TypedDataDomain,
+    types: TypedDataTypes,
+    message: Record<string, unknown>,
+    signature: string,
+    primaryType: string,
+  ): Promise<boolean> {
+    try {
+      // viem expects hex domain and hex addresses; convert anything Base58.
+      const viemDomain: ViemTypedDataDomain = {
+        name: domain.name,
+        version: domain.version,
+        chainId: domain.chainId,
+        verifyingContract: domain.verifyingContract
+          ? (toEvmHex(domain.verifyingContract) as `0x${string}`)
+          : undefined,
+        ...(domain.salt ? { salt: domain.salt as `0x${string}` } : {}),
+      };
+
+      // Strip an `EIP712Domain` entry if a caller mistakenly added it; viem
+      // injects this from the domain object.
+      const typesNoDomain: TypedDataTypes = { ...types };
+      delete (typesNoDomain as Record<string, unknown>)['EIP712Domain'];
+
+      const sigBytes = signature.startsWith('0x')
+        ? (signature as `0x${string}`)
+        : (`0x${signature}` as `0x${string}`);
+
+      const recovered = await recoverTypedDataAddress({
+        domain: viemDomain,
+        types: typesNoDomain as Record<string, ReadonlyArray<{ name: string; type: string }>>,
+        primaryType,
+        message,
+        signature: sigBytes,
+      });
+
+      const expectedHex = toEvmHex(address).toLowerCase();
+      return recovered.toLowerCase() === expectedHex;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[TronFacilitatorSigner] verifyTypedData failed:', err);
+      return false;
+    }
+  }
+
+  /**
+   * Write contract on TRON: build via tronweb's `triggerSmartContract`, sign
+   * via the wallet, broadcast.
+   *
+   * The function selector must match the on-chain ABI exactly, including
+   * tuple bracket types. Example for PaymentPermit:
+   *
+   *   permitTransferFrom(((uint8,bytes16,uint256,uint256,uint256),
+   *                       address,address,(address,uint256,address),(address,uint256)),
+   *                      address,bytes)
+   *
+   * @param contractAddress Base58 (T...) or hex (41...) contract address.
+   * @param _abi Unused for TRON (we use function selector directly); kept for interface parity.
+   * @param method Method signature string with full type bracket layout (see note above).
+   * @param args Parameter array shaped per tronweb's `triggerSmartContract` schema:
+   *             `[{ type: 'address', value: '0x...' }, { type: 'tuple(...)', value: [...] }, ...]`.
+   */
+  async writeContract(
+    contractAddress: string,
+    _abi: string | unknown[],
+    method: string,
+    args: unknown[],
+    network: string,
+  ): Promise<string | null> {
+    try {
+      const tw = this.getTronWeb(network);
+
+      const tx = await tw.transactionBuilder.triggerSmartContract(
+        contractAddress,
+        method,
+        {
+          feeLimit: 1_000_000_000, // 1000 TRX cap
+          callValue: 0,
+          // Active permission (id=2) required for multi-sig facilitator
+          // accounts whose owner threshold is > 1.
+          permissionId: this.permissionId,
+        },
+        args,
+        this.getAddress(),
+      );
+
+      if (!tx.result?.result) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[TronFacilitatorSigner] triggerSmartContract failed: ${JSON.stringify(tx)}`,
+        );
+        return null;
+      }
+
+      // Sign: prefer direct private-key signing via tronweb (matches Python's
+      // tronpy direct-sign path). agent-wallet's TRON signTransaction can
+      // round-trip the raw_data and produce an invalid signature.
+      let signedTx: unknown;
+      if (this.privateKey) {
+        signedTx = await (tw.trx as unknown as {
+          sign: (txObj: unknown, pk: string) => Promise<unknown>;
+        }).sign(tx.transaction, this.privateKey);
+      } else {
+        const rawResult = await this.wallet.signTransaction(
+          tx.transaction as Record<string, unknown>,
+        );
+        const sigHex = this.extractTronSignature(rawResult);
+        signedTx = {
+          ...(tx.transaction as Record<string, unknown>),
+          signature: [sigHex],
+        };
+      }
+
+      // Broadcast
+      const broadcast = await tw.trx.sendRawTransaction(signedTx);
+      if (!broadcast.result) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[TronFacilitatorSigner] sendRawTransaction failed: ${JSON.stringify(broadcast)}`,
+        );
+        return null;
+      }
+      return broadcast.txid;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[TronFacilitatorSigner] writeContract error:', err);
+      return null;
+    }
+  }
+
+  /**
+   * Check TRC20 balance via `triggerConstantContract` (read-only call).
+   */
+  async checkBalance(
+    token: string,
+    network: string,
+    address?: string,
+  ): Promise<bigint> {
+    try {
+      const targetAddress = address ?? this.getAddress();
+      const ownerHex = toEvmHex(targetAddress);
+
+      const tw = this.getTronWeb(network);
+      const result = await tw.transactionBuilder.triggerConstantContract(
+        token,
+        'balanceOf(address)',
+        {},
+        [{ type: 'address', value: ownerHex }],
+        this.getAddress(),
+      );
+
+      if (result.result?.result && result.constant_result?.length) {
+        return BigInt('0x' + result.constant_result[0]);
+      }
+      // Suppress unused vars from helper imports
+      void hexToBytes;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[TronFacilitatorSigner] checkBalance failed for ${token}:`, err);
+    }
+    return BigInt(0);
+  }
+
+  /**
+   * Poll tronpy `getTransactionInfo` until the tx has a blockNumber.
+   *
+   * Returns `{status: 'confirmed' | 'failed'}` based on `receipt.result`.
+   */
+  async waitForTransactionReceipt(
+    txHash: string,
+    network: string,
+    timeoutMs: number = 120_000,
+  ): Promise<TransactionReceipt> {
+    const tw = this.getTronWeb(network);
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      try {
+        const info = await tw.trx.getTransactionInfo(txHash);
+        if (info && info.blockNumber) {
+          const success = info.receipt?.result === 'SUCCESS';
+          return {
+            hash: txHash,
+            blockNumber: String(info.blockNumber),
+            status: success ? 'confirmed' : 'failed',
+          };
+        }
+      } catch {
+        // Not yet propagated to the queried node — keep polling.
+      }
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+    }
+
+    throw new Error(
+      `Transaction ${txHash} not confirmed within ${Math.round(timeoutMs / 1000)}s`,
+    );
+  }
+}

--- a/typescript/packages/x402/src/signers/facilitator/tronSigner.ts
+++ b/typescript/packages/x402/src/signers/facilitator/tronSigner.ts
@@ -61,6 +61,7 @@ export class TronFacilitatorSigner extends FacilitatorSigner {
    * round-trip can drift the tx's raw_data and invalidate the txID/signature).
    */
   private privateKey: string | null = null;
+  private privateKeyAddress: string | null = null;
   /**
    * TRON permission id used when building transactions.
    * Default `2` = active permission (required for multi-sig facilitator
@@ -78,6 +79,11 @@ export class TronFacilitatorSigner extends FacilitatorSigner {
         null;
       if (pk) {
         this.privateKey = pk.startsWith('0x') ? pk.slice(2) : pk;
+        const derived = TronWebClass.address.fromPrivateKey(this.privateKey);
+        if (!derived) {
+          throw new Error('Invalid TRON facilitator private key');
+        }
+        this.privateKeyAddress = derived;
       }
       const permId = process.env?.TRON_PERMISSION_ID;
       if (permId) {
@@ -92,7 +98,20 @@ export class TronFacilitatorSigner extends FacilitatorSigner {
     const provider = resolveWalletProvider({ network: 'tron' });
     const wallet = await provider.getActiveWallet();
     const signer = new TronFacilitatorSigner(wallet as unknown as AgentWallet);
-    signer.setAddress(await wallet.getAddress());
+    const walletAddress = await wallet.getAddress();
+    if (signer.privateKeyAddress) {
+      signer.setAddress(signer.privateKeyAddress);
+      if (walletAddress !== signer.privateKeyAddress) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[TronFacilitatorSigner] TRON_FACILITATOR_PRIVATE_KEY/TRON_PRIVATE_KEY address ` +
+            `${signer.privateKeyAddress} differs from agent-wallet active address ${walletAddress}; ` +
+            `using the private-key address for facilitator settlement.`,
+        );
+      }
+    } else {
+      signer.setAddress(walletAddress);
+    }
     return signer;
   }
 
@@ -259,6 +278,11 @@ export class TronFacilitatorSigner extends FacilitatorSigner {
       // round-trip the raw_data and produce an invalid signature.
       let signedTx: unknown;
       if (this.privateKey) {
+        if (this.privateKeyAddress && this.privateKeyAddress !== this.getAddress()) {
+          throw new Error(
+            `TRON private key address ${this.privateKeyAddress} does not match transaction owner ${this.getAddress()}`,
+          );
+        }
         signedTx = await (tw.trx as unknown as {
           sign: (txObj: unknown, pk: string) => Promise<unknown>;
         }).sign(tx.transaction, this.privateKey);

--- a/typescript/packages/x402/src/signers/index.ts
+++ b/typescript/packages/x402/src/signers/index.ts
@@ -12,3 +12,13 @@ export type {
   TronNetwork,
 } from './types.js';
 export { TRON_CHAIN_IDS } from './types.js';
+
+// Facilitator signers (verify + write_contract + receipt polling)
+export { FacilitatorSigner } from './facilitator/base.js';
+export type {
+  TypedDataDomain as FacilitatorTypedDataDomain,
+  TypedDataTypes as FacilitatorTypedDataTypes,
+  TransactionReceipt as FacilitatorTransactionReceipt,
+} from './facilitator/base.js';
+export { TronFacilitatorSigner } from './facilitator/tronSigner.js';
+export { EvmFacilitatorSigner } from './facilitator/evmSigner.js';

--- a/typescript/packages/x402/src/tokens.test.ts
+++ b/typescript/packages/x402/src/tokens.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for {@link parsePrice} — the price-string → smallest-unit asset amount
+ * helper used by ResourceConfig-style server configuration.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parsePrice, registerToken } from './tokens.js';
+
+describe('parsePrice', () => {
+  it('parses an integer amount on a 6-decimal TRON token', () => {
+    const result = parsePrice('1 USDT', 'tron:mainnet');
+    expect(result).toMatchObject({
+      amount: '1000000',
+      asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+      decimals: 6,
+      symbol: 'USDT',
+    });
+  });
+
+  it('parses a fractional amount with full decimal precision', () => {
+    const result = parsePrice('1.25 USDT', 'tron:mainnet');
+    expect(result.amount).toBe('1250000');
+  });
+
+  it('parses zero', () => {
+    const result = parsePrice('0 USDT', 'tron:mainnet');
+    expect(result.amount).toBe('0');
+  });
+
+  it('parses 0.000001 (smallest USDT unit)', () => {
+    const result = parsePrice('0.000001 USDT', 'tron:mainnet');
+    expect(result.amount).toBe('1');
+  });
+
+  it('handles an 18-decimal EVM token', () => {
+    const result = parsePrice('0.5 USDC', 'eip155:97');
+    expect(result.amount).toBe('500000000000000000');
+    expect(result.decimals).toBe(18);
+  });
+
+  it('is case-insensitive on the symbol lookup', () => {
+    const result = parsePrice('1 usdt', 'tron:mainnet');
+    expect(result.symbol).toBe('USDT');
+  });
+
+  it('tolerates extra whitespace', () => {
+    expect(parsePrice('   1.25   USDT  ', 'tron:mainnet').amount).toBe('1250000');
+  });
+
+  it('returns the token version when present (DHLU on BSC testnet)', () => {
+    const result = parsePrice('1 DHLU', 'eip155:97');
+    expect(result.version).toBe('1');
+  });
+
+  it('omits version when the token has none', () => {
+    const result = parsePrice('1 USDT', 'tron:mainnet');
+    expect(result).not.toHaveProperty('version');
+  });
+
+  it('throws on malformed price (single token)', () => {
+    expect(() => parsePrice('1USDT', 'tron:mainnet')).toThrow(/Invalid price format/);
+  });
+
+  it('throws on negative or non-numeric amount', () => {
+    expect(() => parsePrice('-1 USDT', 'tron:mainnet')).toThrow(/Invalid amount/);
+    expect(() => parsePrice('abc USDT', 'tron:mainnet')).toThrow(/Invalid amount/);
+  });
+
+  it('throws on unknown token symbol', () => {
+    expect(() => parsePrice('1 NOTOKEN', 'tron:mainnet')).toThrow(/Unknown token/);
+  });
+
+  it('throws when amount precision exceeds token decimals', () => {
+    // USDT has 6 decimals; 0.0000001 is 7 places
+    expect(() => parsePrice('0.0000001 USDT', 'tron:mainnet')).toThrow(/more decimal places/);
+  });
+
+  it('picks up custom tokens registered at runtime', () => {
+    registerToken('eip155:1', {
+      address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      decimals: 6,
+      name: 'Custom USDT',
+      symbol: 'CUSDT',
+    });
+    const result = parsePrice('2 CUSDT', 'eip155:1');
+    expect(result.asset).toBe('0xdAC17F958D2ee523a2206206994597C13D831ec7');
+    expect(result.amount).toBe('2000000');
+  });
+});

--- a/typescript/packages/x402/src/tokens.ts
+++ b/typescript/packages/x402/src/tokens.ts
@@ -115,3 +115,72 @@ export function registerToken(network: string, token: TokenInfo): void {
   }
   TOKENS[network][token.symbol.toUpperCase()] = token;
 }
+
+/** Parsed asset amount returned by {@link parsePrice}. */
+export interface AssetAmount {
+  /** Amount in smallest unit (e.g. "1000000" for 1 USDT with 6 decimals). */
+  amount: string;
+  /** Token contract address on the network. */
+  asset: string;
+  /** Token decimals. */
+  decimals: number;
+  /** Token symbol (e.g. "USDT"). */
+  symbol: string;
+  /** Token display name. */
+  name: string;
+  /** EIP-712 / TIP-712 contract version (for permit) when applicable. */
+  version?: string;
+}
+
+/**
+ * Parse a human-readable price string into a typed asset amount.
+ *
+ * @param price - `"<decimal-amount> <symbol>"` (e.g. `"1.25 USDT"` or `"100 USDC"`).
+ *                Whitespace-tolerant. `<symbol>` lookup is case-insensitive.
+ * @param network - CAIP-2 network identifier (e.g. `"tron:nile"`, `"eip155:97"`).
+ *
+ * @throws if the price format is invalid, the amount cannot be parsed,
+ *         the token is not registered on `network`, or the amount has more
+ *         decimal places than the token supports.
+ *
+ * Mirrors `bankofai.x402.tokens.TokenRegistry.parse_price`.
+ */
+export function parsePrice(price: string, network: string): AssetAmount {
+  const parts = price.trim().split(/\s+/);
+  if (parts.length !== 2) {
+    throw new Error(
+      `Invalid price format: "${price}". Expected "<amount> <symbol>" (e.g. "1.25 USDT").`,
+    );
+  }
+  const [amountStr, symbol] = parts as [string, string];
+
+  if (!/^\d+(\.\d+)?$/.test(amountStr)) {
+    throw new Error(`Invalid amount in price "${price}": "${amountStr}" is not a non-negative decimal.`);
+  }
+
+  const token = getToken(network, symbol);
+  if (!token) {
+    throw new Error(`Unknown token "${symbol}" on network "${network}".`);
+  }
+
+  // BigInt-safe smallest-unit conversion. Reject precision overflow.
+  const [intPart, fracPart = ''] = amountStr.split('.') as [string, string?];
+  if (fracPart.length > token.decimals) {
+    throw new Error(
+      `Amount "${amountStr}" has more decimal places (${fracPart.length}) than ${symbol} supports (${token.decimals}).`,
+    );
+  }
+  const paddedFrac = fracPart.padEnd(token.decimals, '0');
+  // strip leading zeros to keep canonical numeric string
+  const combined = `${intPart}${paddedFrac}`.replace(/^0+(?=\d)/, '');
+  const amount = combined === '' ? '0' : combined;
+
+  return {
+    amount,
+    asset: token.address,
+    decimals: token.decimals,
+    symbol: token.symbol,
+    name: token.name,
+    ...(token.version !== undefined ? { version: token.version } : {}),
+  };
+}

--- a/typescript/packages/x402/src/utils/encoding.ts
+++ b/typescript/packages/x402/src/utils/encoding.ts
@@ -74,6 +74,22 @@ export function decodePaymentPayload<T>(encoded: string): T {
 }
 
 /**
+ * Generate a random 16-byte payment ID, formatted as `0x` + 32 hex chars.
+ *
+ * Used by `X402Server.createPaymentRequiredResponse` when the caller doesn't
+ * supply an explicit `paymentId`. Mirrors Python `generate_payment_id`.
+ */
+export function generatePaymentId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let hex = '';
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, '0');
+  }
+  return `0x${hex}`;
+}
+
+/**
  * Convert hex string to Uint8Array
  */
 export function hexToBytes(hex: string): Uint8Array {

--- a/typescript/packages/x402/src/utils/gasfree.ts
+++ b/typescript/packages/x402/src/utils/gasfree.ts
@@ -1,6 +1,8 @@
 import {
   GASFREE_PRIMARY_TYPE,
 } from '../abi.js';
+import { getChainId, getGasFreeControllerAddress } from '../config.js';
+import { toEvmHex } from '../address.js';
 
 /**
  * GasFree utility functions for API interaction and domain helpers.
@@ -76,6 +78,15 @@ export const GASFREE_TYPES = {
     { name: 'nonce', type: 'uint256' },
   ],
 } as const;
+
+export function getGasFreeDomain(network: string) {
+  return {
+    name: 'GasFreeController',
+    version: 'V1.0.0',
+    chainId: getChainId(network),
+    verifyingContract: toEvmHex(getGasFreeControllerAddress(network)),
+  };
+}
 
 const DEFAULT_TIMEOUT_MS = 30000;
 

--- a/typescript/packages/x402/src/utils/index.ts
+++ b/typescript/packages/x402/src/utils/index.ts
@@ -3,5 +3,13 @@
  */
 
 export * from './encoding.js';
-export { encodeBase64, decodeBase64, decodeBase64ToBytes, hexToBytes, bytesToHex, paymentIdToBytes } from './encoding.js';
+export {
+  encodeBase64,
+  decodeBase64,
+  decodeBase64ToBytes,
+  generatePaymentId,
+  hexToBytes,
+  bytesToHex,
+  paymentIdToBytes,
+} from './encoding.js';
 export * from './gasfree.js';

--- a/typescript/packages/x402/src/utils/tx_verification.test.ts
+++ b/typescript/packages/x402/src/utils/tx_verification.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for transaction verification base + factory.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { PaymentPayload, PaymentRequirements } from '../types/index.js';
+import {
+  BaseTransactionVerifier,
+  type TransactionInfo,
+  type TransferEvent,
+  getVerifierForNetwork,
+  registerVerifierFactory,
+} from './tx_verification.js';
+
+const REQ: PaymentRequirements = {
+  scheme: 'exact_permit',
+  network: 'tron:nile',
+  amount: '1000000',
+  asset: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  payTo: 'TJWdoJk8KyrfxZ2iDUqz7fwpXaMkNqPehx',
+};
+const PAYLOAD: PaymentPayload = {
+  x402Version: 2,
+  accepted: REQ,
+  payload: { signature: '0x' + 'aa'.repeat(65) },
+} as PaymentPayload;
+
+/** Minimal verifier subclass driven by a canned `getTransactionInfo`. */
+class StubVerifier extends BaseTransactionVerifier {
+  constructor(private readonly info: TransactionInfo | (() => Promise<TransactionInfo>)) {
+    super();
+  }
+  async getTransactionInfo() {
+    return typeof this.info === 'function' ? this.info() : this.info;
+  }
+  async getTransactionTransfers(): Promise<TransferEvent[]> {
+    return [];
+  }
+  normalizeAddress(addr: string): string {
+    return addr;
+  }
+}
+
+describe('BaseTransactionVerifier.verifyTransaction', () => {
+  it('returns success when transaction status is "success"', async () => {
+    const verifier = new StubVerifier({ status: 'success', blockNumber: '12345' });
+    const result = await verifier.verifyTransaction('0xtx', PAYLOAD, REQ);
+    expect(result.success).toBe(true);
+    expect(result.statusVerified).toBe(true);
+    expect(result.blockNumber).toBe('12345');
+    expect(result.txHash).toBe('0xtx');
+  });
+
+  it('returns failure when status is "failed"', async () => {
+    const verifier = new StubVerifier({ status: 'failed', blockNumber: '12345' });
+    const result = await verifier.verifyTransaction('0xtx', PAYLOAD, REQ);
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe('transaction_failed_on_chain');
+    expect(result.statusVerified).toBe(false);
+  });
+
+  it('returns failure when status is "0" (numeric-as-string)', async () => {
+    const verifier = new StubVerifier({ status: '0' });
+    const result = await verifier.verifyTransaction('0xtx', PAYLOAD, REQ);
+    expect(result.success).toBe(false);
+  });
+
+  it('returns failure when status is missing / empty', async () => {
+    const verifier = new StubVerifier({ blockNumber: '1' });
+    const result = await verifier.verifyTransaction('0xtx', PAYLOAD, REQ);
+    expect(result.success).toBe(false);
+  });
+
+  it('catches getTransactionInfo errors into verification_error', async () => {
+    const verifier = new StubVerifier(async () => {
+      throw new Error('rpc down');
+    });
+    const result = await verifier.verifyTransaction('0xtx', PAYLOAD, REQ);
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toMatch(/verification_error: rpc down/);
+  });
+
+  it('paymentVerified / feeVerified default false at base level', async () => {
+    const verifier = new StubVerifier({ status: 'success' });
+    const result = await verifier.verifyTransaction('0xtx', PAYLOAD, REQ);
+    expect(result.paymentVerified).toBe(false);
+    expect(result.feeVerified).toBe(false);
+  });
+});
+
+describe('getVerifierForNetwork / registerVerifierFactory', () => {
+  // Snapshot/restore is overkill — these tests use a unique prefix.
+  const TEST_PREFIX = 'testnet:';
+  afterEach(() => {
+    // No public unregister; just leave the test factory in place — prefix is unique.
+  });
+
+  it('throws when no factory matches the network prefix', () => {
+    expect(() => getVerifierForNetwork('unknown:42')).toThrow(
+      /No transaction verifier registered/,
+    );
+  });
+
+  it('returns a verifier from a registered factory', () => {
+    const fakeVerifier = {
+      verifyTransaction: async () => {
+        throw new Error('not implemented');
+      },
+      getTransactionTransfers: async () => [],
+    };
+    registerVerifierFactory(TEST_PREFIX, () => fakeVerifier);
+    const v = getVerifierForNetwork(`${TEST_PREFIX}foo`);
+    expect(v).toBe(fakeVerifier);
+  });
+
+  it('forwards options to the factory', () => {
+    let receivedOpts: { rpcUrl?: string } | undefined;
+    registerVerifierFactory('opts-test:', (_network, opts) => {
+      receivedOpts = opts;
+      return {
+        verifyTransaction: async () => ({} as never),
+        getTransactionTransfers: async () => [],
+      };
+    });
+    getVerifierForNetwork('opts-test:1', { rpcUrl: 'https://rpc.example' });
+    expect(receivedOpts).toEqual({ rpcUrl: 'https://rpc.example' });
+  });
+});

--- a/typescript/packages/x402/src/utils/tx_verification.ts
+++ b/typescript/packages/x402/src/utils/tx_verification.ts
@@ -1,0 +1,180 @@
+/**
+ * Transaction Verification Utilities
+ *
+ * Generic functionality to verify blockchain transaction results after the
+ * facilitator reports settlement, ensuring on-chain transfers match expected
+ * parameters. Mirrors `bankofai.x402.utils.tx_verification`.
+ *
+ * This module provides the **base contracts**. Chain-specific implementations
+ * (TRON via tronweb, EVM via viem) subclass {@link BaseTransactionVerifier}
+ * and plug in via {@link getVerifierForNetwork}.
+ */
+
+import type { PaymentPayload, PaymentRequirements } from '../types/index.js';
+
+/** A single token transfer event extracted from a transaction. */
+export interface TransferEvent {
+  /** Token contract address. */
+  token: string;
+  /** Sender address. */
+  fromAddr: string;
+  /** Recipient address. */
+  toAddr: string;
+  /** Transfer amount in smallest unit (as a BigInt-safe string). */
+  amount: string;
+}
+
+/** Outcome of {@link TransactionVerifier.verifyTransaction}. */
+export interface TransactionVerificationResult {
+  success: boolean;
+  txHash: string;
+  blockNumber?: string;
+  errorReason?: string;
+  transfers?: TransferEvent[];
+  /** Whether the on-chain transaction status was "success". */
+  statusVerified: boolean;
+  /** Whether the payment transfer (amount + recipient) was verified. */
+  paymentVerified: boolean;
+  /** Whether the facilitator fee transfer was verified (when applicable). */
+  feeVerified: boolean;
+}
+
+/**
+ * Interface for transaction verification implementations. One per chain family.
+ *
+ * Wraps the chain's transaction-info / transfer-events RPC and applies the
+ * canonical "did the right transfer happen" check.
+ */
+export interface TransactionVerifier {
+  verifyTransaction(
+    txHash: string,
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<TransactionVerificationResult>;
+  getTransactionTransfers(
+    txHash: string,
+    tokenAddress: string,
+  ): Promise<TransferEvent[]>;
+}
+
+/** Generic transaction-info shape returned by chain-specific RPC adapters. */
+export interface TransactionInfo {
+  status?: string | number;
+  blockNumber?: string;
+}
+
+/**
+ * Abstract base class for transaction verifiers. Subclasses implement the
+ * chain-specific RPC calls; the canonical verification flow lives here.
+ *
+ * Mirrors Python `BaseTransactionVerifier`. Like the Python base, the default
+ * {@link verifyTransaction} only checks that the on-chain transaction
+ * succeeded — chain-specific subclasses MAY override for richer transfer +
+ * fee verification.
+ */
+export abstract class BaseTransactionVerifier implements TransactionVerifier {
+  /** Chain-specific: pull transaction info (status, blockNumber) from RPC. */
+  abstract getTransactionInfo(txHash: string): Promise<TransactionInfo>;
+
+  /** Chain-specific: pull token transfer events from the transaction. */
+  abstract getTransactionTransfers(
+    txHash: string,
+    tokenAddress: string,
+  ): Promise<TransferEvent[]>;
+
+  /** Chain-specific: normalize an address for equality comparison. */
+  abstract normalizeAddress(address: string): string;
+
+  /**
+   * Canonical verification flow: pull transaction info, check status.
+   *
+   * Subclasses can override to additionally verify transfer amounts /
+   * fee transfers — set `paymentVerified` / `feeVerified` accordingly.
+   */
+  async verifyTransaction(
+    txHash: string,
+    _payload: PaymentPayload,
+    _requirements: PaymentRequirements,
+  ): Promise<TransactionVerificationResult> {
+    try {
+      const info = await this.getTransactionInfo(txHash);
+      const status = String(info.status ?? '').toLowerCase();
+      if (status === 'failed' || status === '0' || status === '') {
+        return {
+          success: false,
+          txHash,
+          ...(info.blockNumber ? { blockNumber: info.blockNumber } : {}),
+          errorReason: 'transaction_failed_on_chain',
+          statusVerified: false,
+          paymentVerified: false,
+          feeVerified: false,
+        };
+      }
+      return {
+        success: true,
+        txHash,
+        ...(info.blockNumber ? { blockNumber: info.blockNumber } : {}),
+        statusVerified: true,
+        // Base impl doesn't check transfers — subclasses set these when they do.
+        paymentVerified: false,
+        feeVerified: false,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        txHash,
+        errorReason: `verification_error: ${(err as Error).message}`,
+        statusVerified: false,
+        paymentVerified: false,
+        feeVerified: false,
+      };
+    }
+  }
+}
+
+/**
+ * Registry of (network-prefix → verifier factory) entries.
+ *
+ * Chain-specific verifiers register themselves at module load (e.g. a TRON
+ * verifier package would call `registerVerifierFactory('tron:', ...)`); the
+ * core `@bankofai/x402` package ships no concrete verifiers itself.
+ */
+type VerifierFactory = (network: string, opts?: { rpcUrl?: string }) => TransactionVerifier;
+const verifierFactories = new Map<string, VerifierFactory>();
+
+/**
+ * Register a verifier factory for a network prefix (e.g. `"tron:"`, `"eip155:"`).
+ * Calls override any prior registration for the same prefix.
+ */
+export function registerVerifierFactory(prefix: string, factory: VerifierFactory): void {
+  verifierFactories.set(prefix, factory);
+}
+
+/**
+ * Resolve a {@link TransactionVerifier} for a given network.
+ *
+ * Throws if no factory has been registered for the network's prefix. Callers
+ * that want optional verification (e.g. server middleware) should catch this
+ * and skip verification gracefully.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const verifier = getVerifierForNetwork('tron:nile');
+ *   const result = await verifier.verifyTransaction(txHash, payload, requirements);
+ * } catch {
+ *   // No verifier registered → skip on-chain re-check (facilitator is trusted).
+ * }
+ * ```
+ */
+export function getVerifierForNetwork(
+  network: string,
+  opts?: { rpcUrl?: string },
+): TransactionVerifier {
+  for (const [prefix, factory] of verifierFactories) {
+    if (network.startsWith(prefix)) {
+      return factory(network, opts);
+    }
+  }
+  throw new Error(`No transaction verifier registered for network: ${network}`);
+}

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -30,9 +30,18 @@ importers:
         specifier: ^2.45.2
         version: 2.45.2(typescript@5.9.3)(zod@3.25.76)
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.31
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      hono:
+        specifier: ^4.12.18
+        version: 4.12.18
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -540,8 +549,23 @@ packages:
   '@types/bn.js@4.11.6':
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/node@20.19.31':
     resolution: {integrity: sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==}
@@ -552,8 +576,20 @@ packages:
   '@types/pbkdf2@3.1.2':
     resolution: {integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/secp256k1@4.0.7':
     resolution: {integrity: sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -580,6 +616,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
@@ -634,6 +674,10 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
@@ -657,6 +701,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -699,6 +747,22 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-js-pure@3.48.0:
     resolution: {integrity: sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==}
 
@@ -736,6 +800,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -744,8 +812,15 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -768,8 +843,15 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   eth-sig-util@3.0.1:
     resolution: {integrity: sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==}
@@ -812,6 +894,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -820,6 +906,10 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -837,6 +927,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -893,6 +991,14 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -907,6 +1013,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -914,6 +1024,9 @@ packages:
   is-hex-prefixed@1.0.0:
     resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
     engines: {node: '>=6.5.0', npm: '>=3'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -964,6 +1077,14 @@ packages:
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -971,9 +1092,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -1000,6 +1129,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
 
@@ -1013,6 +1146,17 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -1030,6 +1174,10 @@ packages:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1037,6 +1185,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1072,11 +1223,27 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -1104,6 +1271,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -1125,12 +1296,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sha.js@2.4.12:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
@@ -1145,6 +1327,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1158,6 +1356,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1194,6 +1396,10 @@ packages:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tronweb@6.1.1:
     resolution: {integrity: sha512-9i2N+cTkRY7Y1B/V0+ZVwCYZFhdFDalh8sbI8Tpj5O65hMURvjFnaP1u/dTwVnVw07d9M143/19KarxeAzK6pg==}
 
@@ -1209,6 +1415,10 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -1228,12 +1438,20 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   validator@13.15.23:
     resolution: {integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==}
     engines: {node: '>= 0.10'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   viem@2.45.2:
     resolution: {integrity: sha512-GXPMmj0ukqFNL87sgpsZBy4CjGvsFQk42/EUdsn8dv3ZWtL4ukDXNCM0nME2hU0IcuS29CuUbrwbZN6iWxAipw==}
@@ -1317,6 +1535,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
@@ -1736,7 +1957,31 @@ snapshots:
     dependencies:
       '@types/node': 20.19.31
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.31
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.31
+
   '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.31
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/node@20.19.31':
     dependencies:
@@ -1750,8 +1995,21 @@ snapshots:
     dependencies:
       '@types/node': 20.19.31
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/secp256k1@4.0.7':
     dependencies:
+      '@types/node': 20.19.31
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.31
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
       '@types/node': 20.19.31
 
   '@vitest/expect@1.6.1':
@@ -1787,6 +2045,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.25.76
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-walk@8.3.4:
     dependencies:
@@ -1832,6 +2095,20 @@ snapshots:
 
   bn.js@5.2.3: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brorand@1.1.0: {}
 
   browserify-aes@1.2.0:
@@ -1868,6 +2145,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -1918,6 +2197,14 @@ snapshots:
 
   confbox@0.1.8: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-js-pure@3.48.0: {}
 
   core-util-is@1.0.3: {}
@@ -1961,6 +2248,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   diff-sequences@29.6.3: {}
 
   dunder-proto@1.0.1:
@@ -1968,6 +2257,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ee-first@1.1.1: {}
 
   elliptic@6.6.1:
     dependencies:
@@ -1978,6 +2269,8 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  encodeurl@2.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -2020,9 +2313,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
 
   eth-sig-util@3.0.1:
     dependencies:
@@ -2125,6 +2422,39 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -2134,6 +2464,17 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   follow-redirects@1.15.11: {}
 
@@ -2148,6 +2489,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2212,6 +2557,16 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  hono@4.12.18: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-signals@5.0.0: {}
 
   iconv-lite@0.7.2:
@@ -2222,9 +2577,13 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ipaddr.js@1.9.1: {}
+
   is-callable@1.2.7: {}
 
   is-hex-prefixed@1.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@3.0.0: {}
 
@@ -2273,13 +2632,23 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@4.0.0: {}
 
@@ -2300,6 +2669,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   node-addon-api@2.0.2: {}
 
   node-addon-api@5.1.0: {}
@@ -2309,6 +2680,16 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@6.0.0:
     dependencies:
@@ -2333,9 +2714,13 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
+  parseurl@1.3.3: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@1.1.2: {}
 
@@ -2376,11 +2761,29 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-is@18.3.1: {}
 
@@ -2442,6 +2845,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -2458,6 +2871,31 @@ snapshots:
 
   semver@7.7.1: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -2468,6 +2906,8 @@ snapshots:
       has-property-descriptors: 1.0.2
 
   setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
 
   sha.js@2.4.12:
     dependencies:
@@ -2481,6 +2921,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -2488,6 +2956,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -2521,6 +2991,8 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
+  toidentifier@1.0.1: {}
+
   tronweb@6.1.1:
     dependencies:
       '@babel/runtime': 7.26.10
@@ -2545,6 +3017,12 @@ snapshots:
 
   type-detect@4.1.0: {}
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -2559,9 +3037,13 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unpipe@1.0.0: {}
+
   util-deprecate@1.0.2: {}
 
   validator@13.15.23: {}
+
+  vary@1.1.2: {}
 
   viem@2.45.2(typescript@5.9.3)(zod@3.25.76):
     dependencies:
@@ -2659,6 +3141,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
 
   ws@8.17.1: {}
 


### PR DESCRIPTION
## Summary
- complete TypeScript facilitator parity release line for 0.6.0
- bump TypeScript and Python package metadata to 0.6.0
- align release notes, changelog, and roadmap for QA/release readiness

## Verification
- pnpm --dir typescript/packages/x402 build
- pnpm --dir typescript/packages/x402 test (19 files / 158 tests)
- npm pack --dry-run for @bankofai/x402@0.6.0
- Python pyproject metadata smoke

## QA smoke txids
- exact_gasfree: 97ec5443edaf4bbe8633ee8fc0dc923c4809df4f95625718d1f33e499cf2313d
- exact_permit: 6aeccd9ff25e9c241b08082ea11149177597ae041daf6aa5dd6c0b7c0634d20a