### PR TITLE
fix(tron): restore wallet CLI signing for exact_permit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ x402 currently supports the **TRON** and **BSC** networks, with plans to expand 
 
 ## Current Release
 
-Version `0.6.0` completes the TypeScript parity milestone against the Python SDK. Both SDKs support facilitator verify and settle flows for `exact`, `exact_permit`, and `exact_gasfree`, with TRON Nile smoke coverage for permit and GasFree settlement.
+Version `0.6.1` fixes TRON `exact_permit` facilitator settlement through wallet CLI backed signers while preserving the 0.6.0 TypeScript parity milestone. Both SDKs support facilitator verify and settle flows for `exact`, `exact_permit`, and `exact_gasfree`, with TRON Nile smoke coverage for permit and GasFree settlement.
 
 ## Features
 
@@ -36,7 +36,7 @@ Version `0.6.0` completes the TypeScript parity milestone against the Python SDK
 The Python SDK includes support for Server (FastAPI/Flask), Client, and Facilitator.
 
 ```bash
-pip install "bankofai-x402[all]==0.6.0"
+pip install "bankofai-x402[all]==0.6.1"
 ```
 
 For local development from source, use `pip install -e .[all]` inside `python/x402`.
@@ -45,7 +45,7 @@ For local development from source, use `pip install -e .[all]` inside `python/x4
 The TypeScript SDK provides client, server, and facilitator integration tools.
 
 ```bash
-npm install @bankofai/x402@0.6.0
+npm install @bankofai/x402@0.6.1
 ```
 
 ## AI Agent Integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+# v0.6.1 — TRON exact_permit Wallet CLI Fix
+
+Release date: June 24, 2026
+
+## Changes
+
+- **Python TRON facilitator signer**: restored wallet CLI / `agent-wallet` transaction signing for contract writes while keeping active permission support through `TRON_PERMISSION_ID` (default `2`).
+- **`exact_permit` settlement**: facilitator settlement no longer requires `TRON_FACILITATOR_PRIVATE_KEY` / `TRON_PRIVATE_KEY` when the active wallet is already available through wallet CLI.
+- **Version alignment**: Python package metadata, runtime `bankofai.x402.__version__`, and TypeScript package metadata are aligned to `0.6.1`.
+
+## Verification
+
+- Python signer regression tests passed for TRON facilitator contract writes and existing client signer wallet payload behavior.
+
 # v0.6.0 — TypeScript / Python Facilitator Parity
 
 Release date: May 13, 2026

--- a/python/x402/README.md
+++ b/python/x402/README.md
@@ -2,7 +2,7 @@
 
 Python SDK for the x402 payment protocol — supports TRON and EVM (BSC) networks.
 
-Current release: `bankofai-x402==0.6.0`. This release is aligned with the TypeScript SDK for client, server, and facilitator `exact`, `exact_permit`, and `exact_gasfree` flows.
+Current release: `bankofai-x402==0.6.1`. This release fixes TRON `exact_permit` facilitator settlement through wallet CLI backed signers and remains aligned with the TypeScript SDK for client, server, and facilitator `exact`, `exact_permit`, and `exact_gasfree` flows.
 
 ## Compatibility Notes
 
@@ -13,7 +13,7 @@ Current release: `bankofai-x402==0.6.0`. This release is aligned with the TypeSc
 ## Installation
 
 ```bash
-pip install bankofai-x402==0.6.0
+pip install bankofai-x402==0.6.1
 ```
 
 Optional extras:

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "bankofai-x402"
-version = "0.6.0"
+version = "0.6.1"
 description = "x402 Payment Protocol SDK for Python"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/x402/src/bankofai/x402/__init__.py
+++ b/python/x402/src/bankofai/x402/__init__.py
@@ -38,7 +38,7 @@ from bankofai.x402.types import (
     VerifyResponse,
 )
 
-__version__ = "0.5.8"
+__version__ = "0.6.1"
 __all__ = [
     "__version__",
     # Types

--- a/python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py
+++ b/python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py
@@ -30,7 +30,6 @@ class TronFacilitatorSigner(FacilitatorSigner):
         self._wallet = wallet
         self._address: str | None = None
         self._async_tron_clients: dict[str, Any] = {}
-        self._private_key: Any = None  # tronpy PrivateKey for direct signing
         # TRON_PERMISSION_ID: 0=owner, 2=active (default). Multi-sig accounts
         # with owner threshold > 1 must use permission_id=2 (active).
         self._permission_id: int = int(os.environ.get("TRON_PERMISSION_ID", "2"))
@@ -44,17 +43,6 @@ class TronFacilitatorSigner(FacilitatorSigner):
         wallet = await provider.get_active_wallet()
         signer = cls(wallet)
         signer.set_address(await wallet.get_address())
-
-        # Resolve private key for direct tronpy signing (bypasses agent-wallet
-        # sign_transaction which requires raw_data_hex that tronpy does not expose).
-        # Priority: TRON_FACILITATOR_PRIVATE_KEY env → TRON_PRIVATE_KEY env
-        raw_pk = os.environ.get("TRON_FACILITATOR_PRIVATE_KEY") or os.environ.get(
-            "TRON_PRIVATE_KEY"
-        )
-        if raw_pk:
-            from tronpy.keys import PrivateKey as TronPrivateKey
-
-            signer._private_key = TronPrivateKey(bytes.fromhex(raw_pk))
         return signer
 
     @staticmethod
@@ -305,15 +293,10 @@ class TronFacilitatorSigner(FacilitatorSigner):
                 .fee_limit(1_000_000_000)
             )
             txn = await txn_builder.build()
-
-            # Sign directly with tronpy private key (agent-wallet sign_transaction
-            # requires raw_data_hex which tronpy does not expose in to_json()).
-            if self._private_key is None:
-                raise RuntimeError(
-                    "TronFacilitatorSigner: private key not available for signing. "
-                    "Set TRON_FACILITATOR_PRIVATE_KEY or TRON_PRIVATE_KEY in environment."
-                )
-            txn = txn.sign(self._private_key)
+            unsigned_payload = _build_unsigned_tx_payload(txn)
+            raw_result = await self._wallet.sign_transaction(unsigned_payload)
+            sig_hex = self._extract_tron_signature(raw_result)
+            txn._signature = [sig_hex]
 
             # Log transaction details before broadcast
             try:

--- a/python/x402/tests/facilitator/test_tron_signer.py
+++ b/python/x402/tests/facilitator/test_tron_signer.py
@@ -1,0 +1,73 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bankofai.x402.signers.facilitator.tron_signer import TronFacilitatorSigner
+
+
+@pytest.mark.anyio
+async def test_tron_facilitator_write_contract_uses_agent_wallet_with_active_permission(
+    monkeypatch,
+):
+    wallet = MagicMock()
+    wallet.sign_transaction = AsyncMock(return_value='{"signature":["' + ("ab" * 65) + '"]}')
+
+    signer = TronFacilitatorSigner(wallet)
+    signer.set_address("TFacilitatorAddress")
+
+    txn = MagicMock()
+    txn.to_json.return_value = {"txID": "txid", "raw_data": {"fee_limit": 1_000_000_000}}
+    txn.raw_data_hex = "deadbeef"
+    txn.broadcast = AsyncMock(return_value={"txid": "txhash"})
+
+    txn_builder = MagicMock()
+    txn_builder.with_owner.return_value = txn_builder
+    txn_builder.permission_id.return_value = txn_builder
+    txn_builder.fee_limit.return_value = txn_builder
+    txn_builder.build = AsyncMock(return_value=txn)
+
+    function = AsyncMock(return_value=txn_builder)
+    function.function_signature = "permitTransferFrom(...)"
+    function.function_signature_hash = "c13f2d68"
+
+    functions = MagicMock()
+    setattr(functions, "permitTransferFrom", function)
+
+    contract = MagicMock()
+    contract.functions = functions
+
+    client = MagicMock()
+    client.get_account = AsyncMock(return_value={"balance": 1_000_000})
+    client.get_account_resource = AsyncMock(return_value={})
+    client.get_contract = AsyncMock(return_value=contract)
+    signer._ensure_async_tron_client = MagicMock(return_value=client)
+
+    txid = await signer.write_contract(
+        contract_address="TPermitContract",
+        abi="[]",
+        method="permitTransferFrom",
+        args=["permit", "buyer", b"sig"],
+        network="tron:nile",
+    )
+
+    assert txid == "txhash"
+    txn_builder.with_owner.assert_called_once_with("TFacilitatorAddress")
+    txn_builder.permission_id.assert_called_once_with(2)
+    wallet.sign_transaction.assert_awaited_once_with(
+        {
+            "txID": "txid",
+            "raw_data_hex": "deadbeef",
+            "raw_data": {"fee_limit": 1_000_000_000},
+        }
+    )
+    assert txn._signature == ["ab" * 65]
+
+
+@pytest.mark.anyio
+async def test_tron_facilitator_permission_id_env_override(monkeypatch):
+    monkeypatch.setenv("TRON_PERMISSION_ID", "3")
+
+    wallet = MagicMock()
+    signer = TronFacilitatorSigner(wallet)
+
+    assert signer._permission_id == 3

--- a/typescript/packages/x402/README.md
+++ b/typescript/packages/x402/README.md
@@ -2,7 +2,7 @@
 
 TypeScript SDK for the x402 payment protocol. Supports TRON and EVM (BSC) networks with automatic HTTP 402 payment handling.
 
-Current release: `@bankofai/x402@0.6.0`. This release includes TypeScript client, server, and facilitator parity with the Python SDK for `exact`, `exact_permit`, and `exact_gasfree` verify/settle flows.
+Current release: `@bankofai/x402@0.6.1`. This release keeps TypeScript client, server, and facilitator parity with the Python SDK for `exact`, `exact_permit`, and `exact_gasfree` verify/settle flows.
 
 ## Compatibility Notes
 
@@ -22,7 +22,7 @@ Current release: `@bankofai/x402@0.6.0`. This release includes TypeScript client
 ## Installation
 
 ```bash
-npm i @bankofai/x402@0.6.0 tronweb
+npm i @bankofai/x402@0.6.1 tronweb
 ```
 
 ## Quick Start

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankofai/x402",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "x402 TypeScript SDK (TRON and EVM support)",
   "keywords": [
     "x402",


### PR DESCRIPTION
## Summary
- restore TRON facilitator contract writes to sign through wallet CLI / agent-wallet after building the unsigned tronpy transaction payload
- keep active permission support with TRON_PERMISSION_ID defaulting to 2 for multi-sig facilitator accounts
- bump the public package/docs version to 0.6.1 and add a 0.6.1 release note

## Why
Commit e8db1a0 changed exact_permit settlement to sign directly with a raw tronpy private key. That bypassed wallet CLI backed signers and made settlement fail when the facilitator wallet was available through agent-wallet but TRON_FACILITATOR_PRIVATE_KEY / TRON_PRIVATE_KEY was not exported.

## Verification
- /Users/bobo/code/x402/x402/.venv/bin/pytest python/x402/tests/facilitator/test_tron_signer.py python/x402/tests/client/test_signers.py -q
- python -m compileall -q python/x402/src/bankofai/x402/signers/facilitator/tron_signer.py python/x402/tests/facilitator/test_tron_signer.py python/x402/src/bankofai/x402/__init__.py

Note: uv run pytest exits with code 139 in this local environment before pytest output, so verification used the checked-in root .venv pytest runner.