### PR TITLE
ci: add branch policy validators

### DIFF
--- a/scripts/check_branch_policy.sh
+++ b/scripts/check_branch_policy.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+base_branch=${1:-${GITHUB_BASE_REF:-}}
+head_branch=${2:-${GITHUB_HEAD_REF:-}}
+
+if [ -z "$base_branch" ] || [ -z "$head_branch" ]; then
+  printf 'usage: %s <base-branch> <head-branch>\n' "$0" >&2
+  exit 2
+fi
+
+case "$base_branch" in
+  develop)
+    case "$head_branch" in
+      feature/*|feat/*|fix/*|docs/*|chore/*|refactor/*|test/*|perf/*|ci/*|sync/*|release_*|hotfix/*) ;;
+      *)
+        printf 'PRs to develop must come from a development, release, or hotfix branch; got %s.\n' \
+          "$head_branch" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  main)
+    case "$head_branch" in
+      release_*|hotfix/*) ;;
+      *)
+        printf 'PRs to main must come from release_* or hotfix/*; got %s.\n' \
+          "$head_branch" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    printf 'Unsupported target branch: %s.\n' "$base_branch" >&2
+    exit 1
+    ;;
+esac
+
+printf 'Allowed PR route: %s -> %s.\n' "$head_branch" "$base_branch"

--- a/scripts/check_branch_policy.test.sh
+++ b/scripts/check_branch_policy.test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+policy_script=${0%/*}/check_branch_policy.sh
+
+assert_allowed() {
+  if ! sh "$policy_script" "$1" "$2" >/dev/null 2>&1; then
+    printf 'expected route to be allowed: %s -> %s\n' "$2" "$1" >&2
+    exit 1
+  fi
+}
+
+assert_rejected() {
+  if sh "$policy_script" "$1" "$2" >/dev/null 2>&1; then
+    printf 'expected route to be rejected: %s -> %s\n' "$2" "$1" >&2
+    exit 1
+  fi
+}
+
+for prefix in feature feat fix docs chore refactor test perf ci sync; do
+  assert_allowed develop "$prefix/example"
+done
+
+assert_allowed develop release_v1.2.0
+assert_allowed develop hotfix/example
+assert_allowed main release_v1.2.0
+assert_allowed main hotfix/example
+
+assert_rejected develop main
+assert_rejected develop random/example
+assert_rejected main develop
+assert_rejected main chore/example
+assert_rejected main release-v1.2.0
+assert_rejected staging feature/example
+
+printf 'branch policy tests passed\n'

--- a/scripts/check_pr_metadata.mjs
+++ b/scripts/check_pr_metadata.mjs
@@ -1,0 +1,40 @@
+const title = process.env.PR_TITLE ?? process.argv[2] ?? "";
+const body = process.env.PR_BODY ?? process.argv[3] ?? "";
+
+const errors = [];
+const titleLength = [...title].length;
+const titlePattern =
+  /^(feat|fix|refactor|docs|style|test|chore|ci|perf|build|revert)(\([A-Za-z0-9._/*-]+\))?: [a-z0-9].*[^.]$/;
+
+if (titleLength < 10 || titleLength > 72) {
+  errors.push(`PR title must be 10-72 characters; got ${titleLength}.`);
+}
+
+if (!titlePattern.test(title)) {
+  errors.push(
+    "PR title must match type(scope): description, use an allowed type, start the description " +
+      "with a lowercase letter or number, and not end with a period.",
+  );
+}
+
+const bodyWithoutComments = body.replace(/<!--[\s\S]*?-->/g, "");
+const descriptionMatch = bodyWithoutComments.match(
+  /(?:^|\n)## Description[^\S\r\n]*\r?\n([\s\S]*?)(?=\r?\n## |$)/i,
+);
+const description = descriptionMatch?.[1].trim() ?? "";
+const descriptionLength = [...description].length;
+
+if (descriptionLength < 20) {
+  errors.push(
+    `PR Description section must contain at least 20 characters; got ${descriptionLength}.`,
+  );
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(error);
+  }
+  process.exit(1);
+}
+
+console.log(`PR metadata is valid: ${title}`);

--- a/scripts/check_pr_metadata.test.mjs
+++ b/scripts/check_pr_metadata.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const validator = fileURLToPath(new URL("./check_pr_metadata.mjs", import.meta.url));
+const validBody = "## Description\n\nExplain the change and why it is needed.\n\n## Tests\n\nRan tests.";
+
+function validate(title, body) {
+  return spawnSync(process.execPath, [validator, title, body], {
+    encoding: "utf8",
+    env: {},
+  });
+}
+
+test("accepts a valid conventional title and description", () => {
+  const result = validate("ci: add branch policy validators", validBody);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects an unsupported title type", () => {
+  const result = validate("opt: add branch policy validators", validBody);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /must match type\(scope\): description/);
+});
+
+test("rejects a capitalized description and trailing period", () => {
+  const result = validate("ci: Add branch policy validators.", validBody);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /start the description/);
+});
+
+test("ignores HTML comments when measuring the Description section", () => {
+  const result = validate(
+    "ci: add branch policy validators",
+    "## Description\n\n<!-- This text must not count toward the description. -->\n\n## Tests\n\nNone",
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /at least 20 characters; got 0/);
+});
+
+test("rejects a missing Description section", () => {
+  const result = validate("ci: add branch policy validators", "## Tests\n\nRan tests.");
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /at least 20 characters; got 0/);
+});
+
+test("enforces the 72-character title limit", () => {
+  const result = validate(`ci: ${"a".repeat(69)}`, validBody);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /must be 10-72 characters/);
+});


### PR DESCRIPTION
## Description

Add trusted branch-route and pull-request metadata validators before enabling their GitHub Actions workflows. This is phase one of the develop-branch migration and intentionally does not activate enforcement or remove legacy files.

## Tests

- sh scripts/check_branch_policy.test.sh
- node --test scripts/check_pr_metadata.test.mjs
- sh -n scripts/check_branch_policy.sh
- node --check scripts/check_pr_metadata.mjs

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing relevant tests pass
- [x] This PR does not require a Changeset
- [ ] My commits are signed