### PR TITLE
ci: align branch governance and audit workflow

### DIFF
--- a/.github/workflows/audit-pr.yml
+++ b/.github/workflows/audit-pr.yml
@@ -22,11 +22,20 @@ concurrency:
 jobs:
   audit-on-pr:
     name: Audit on pull request
+    # Disabled by default while the self-hosted audit runner is unavailable.
+    # Set the repository variable AUDIT_AUTO_ENABLED=true to restore automatic audits.
     if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, Linux, ARM64, audit-linux]
+    runs-on: ${{ fromJSON(vars.AUDIT_AUTO_ENABLED == 'true' && github.event.pull_request.head.repo.full_name == github.repository && '["self-hosted","Linux","ARM64","audit-linux"]' || '["ubuntu-latest"]') }}
+    env:
+      AUTO_AUDIT_ENABLED: ${{ vars.AUDIT_AUTO_ENABLED == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
+      - name: Automatic audit disabled
+        if: env.AUTO_AUDIT_ENABLED != 'true'
+        run: echo "Automatic audit is disabled"
+
       - name: Checkout PR head
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -34,12 +43,14 @@ jobs:
           persist-credentials: false
 
       - name: Check required tools
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         run: |
           which git
           which jq
           which python3
 
       - name: Create source archive
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         id: archive
         shell: bash
         run: |
@@ -88,6 +99,7 @@ jobs:
           echo "archive_name=${ARCHIVE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Submit audit job
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         id: submit
         shell: bash
         run: |
@@ -110,6 +122,7 @@ jobs:
           echo "report_url=$REPORT_URL" >> "$GITHUB_OUTPUT"
 
       - name: Poll report until ready
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         id: poll
         shell: bash
         run: |
@@ -137,6 +150,7 @@ jobs:
           exit 1
 
       - name: Fetch markdown report
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         shell: bash
         run: |
           REPORT_PATH="${{ steps.submit.outputs.report_url }}"
@@ -152,6 +166,7 @@ jobs:
           fi
 
       - name: Normalize markdown for GitHub comment
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         shell: bash
         run: |
           python3 <<'PY'
@@ -169,6 +184,7 @@ jobs:
           PY
 
       - name: Comment markdown report to PR
+        if: env.AUTO_AUDIT_ENABLED == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -60,3 +60,15 @@ Retain the hotfix branch until both merges are complete.
 | `hotfix/*` | `develop` | Hotfix back-merge |
 
 The `source-and-target` workflow enforces these routes.
+
+## Audit workflow
+
+Automatic pull-request Audit is disabled by default while the self-hosted
+runner is unavailable. Leave the repository variable `AUDIT_AUTO_ENABLED`
+unset, or set it to a value other than `true`, to keep the Audit check as a
+successful no-op on GitHub-hosted infrastructure.
+
+Set `AUDIT_AUTO_ENABLED=true` only after the runner is healthy. Automatic Audit
+then runs only for branches in this repository; fork pull requests remain on
+the no-op path. Authorized users listed in `AUDIT_ALLOWED_USERS` can continue
+to request the existing self-hosted workflow with `/audit-pr`.


### PR DESCRIPTION
## Description

Align branch governance for `main` and `develop`, and disable automatic PR
Audit by default while the self-hosted runner is unavailable. Manual
`/audit-pr` requests remain available to authorized users.

## Tests

- Parsed `.github/workflows/audit-pr.yml` successfully with Ruby YAML.
- Ran `git diff --check`.
- Verified the effective GitHub Ruleset on both `main` and `develop`.

## Branch route

- [x] Normal development targets `develop`
- [ ] Only `release_*` or `hotfix/*` targets `main`

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] I added a Changeset for publishable package changes, or this PR does not require one
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
